### PR TITLE
Functions and Aliases to make life easier

### DIFF
--- a/ssh/rootfs/root/.zshrc
+++ b/ssh/rootfs/root/.zshrc
@@ -83,3 +83,26 @@ source $ZSH/oh-my-zsh.sh
 # Example aliases
 # alias zshconfig="mate ~/.zshrc"
 # alias ohmyzsh="mate ~/.oh-my-zsh"
+# 
+# Control Homeassistant
+alias hadown=curl -d '{"version": "'$1'"}' http://hassio/homeassistant/update
+alias haup=hassio homeassisant update
+alias halog=hassio homeassisant log
+alias hastop=hassio homeassisant stop
+alias hastart=hassio homeassisant start
+alias harestart=hassio homeassisant restart
+alias hacheck=hassio homeassisant check
+
+# Control Supervisor
+alias supup=hassio supervisor update
+alias suplog=hassio supervisor log
+alias supstop=hassio supervisor stop
+alias supstart=hassio supervisor start
+alias suprestart=hassio supervisor restart
+
+# Control Host
+alias hostup=hassio host update
+alias hostlog=hassio host log
+alias hoststop=hassio host stop
+alias hoststart=hassio host start
+alias hostrestart=hassio host reboot

--- a/ssh/rootfs/root/.zshrc
+++ b/ssh/rootfs/root/.zshrc
@@ -4,18 +4,20 @@ DISABLE_AUTO_UPDATE="true"
 COMPLETION_WAITING_DOTS="true"
 plugins=(extract git tmux nmap rsync)
 source $ZSH/oh-my-zsh.sh
-alias hadown=curl -d '{"version": "'$1'"}' http://hassio/homeassistant/update
-alias haup=hassio homeassisant update
-alias halog=hassio homeassisant logs
-alias hastop=hassio homeassisant stop
-alias hastart=hassio homeassisant start
-alias harestart=hassio homeassisant restart
-alias hacheck=hassio homeassisant check
-alias supup=hassio supervisor update
-alias suplog=hassio supervisor logs
-alias supinfo=hassio supervisor info
-alias supreload=hassio supervisor reload
-alias hostup=hassio host update
-alias hostshut=hassio host shutdown
-alias hosthard=hassio host hardware
-alias hostreboot=hassio host reboot
+#alias hadown=curl -d '{"version": "'$1'"}' http://hassio/homeassistant/update
+alias haup='hassio homeassistant update'
+alias halog='hassio homeassistant logs'
+alias hastop='hassio homeassistant stop'
+alias hastart='hassio homeassistant start'
+alias harestart='hassio homeassistant restart'
+alias hacheck='hassio homeassistant check'
+
+alias supup='hassio supervisor update'
+alias suplog='hassio supervisor logs'
+alias supinfo='hassio supervisor info'
+alias supreload='hassio supervisor reload'
+
+alias hostup='hassio host update'
+alias hostshut='hassio host shutdown'
+alias hosthard='hassio host hardware'
+alias hostreboot='hassio host reboot'

--- a/ssh/rootfs/root/.zshrc
+++ b/ssh/rootfs/root/.zshrc
@@ -1,108 +1,21 @@
-# If you come from bash you might have to change your $PATH.
-# export PATH=$HOME/bin:/usr/local/bin:$PATH
-
-# Path to your oh-my-zsh installation.
 export ZSH=$HOME/.oh-my-zsh
-
-# Set name of the theme to load. Optionally, if you set this to "random"
-# it'll load a random theme each time that oh-my-zsh is loaded.
-# See https://github.com/robbyrussell/oh-my-zsh/wiki/Themes
 ZSH_THEME="robbyrussell"
-
-# Uncomment the following line to use case-sensitive completion.
-# CASE_SENSITIVE="true"
-
-# Uncomment the following line to use hyphen-insensitive completion. Case
-# sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
-
-# Uncomment the following line to disable bi-weekly auto-update checks.
 DISABLE_AUTO_UPDATE="true"
-
-# Uncomment the following line to change how often to auto-update (in days).
-# export UPDATE_ZSH_DAYS=13
-
-# Uncomment the following line to disable colors in ls.
-# DISABLE_LS_COLORS="true"
-
-# Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
-
-# Uncomment the following line to enable command auto-correction.
-# ENABLE_CORRECTION="true"
-
-# Uncomment the following line to display red dots whilst waiting for completion.
 COMPLETION_WAITING_DOTS="true"
-
-# Uncomment the following line if you want to disable marking untracked files
-# under VCS as dirty. This makes repository status check for large repositories
-# much, much faster.
-# DISABLE_UNTRACKED_FILES_DIRTY="true"
-
-# Uncomment the following line if you want to change the command execution time
-# stamp shown in the history command output.
-# The optional three formats: "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
-# HIST_STAMPS="mm/dd/yyyy"
-
-# Would you like to use another custom folder than $ZSH/custom?
-# ZSH_CUSTOM=/path/to/new-custom-folder
-
-# Which plugins would you like to load? (plugins can be found in ~/.oh-my-zsh/plugins/*)
-# Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-# Add wisely, as too many plugins slow down shell startup.
 plugins=(extract git tmux nmap rsync)
-
 source $ZSH/oh-my-zsh.sh
-
-# User configuration
-
-# export MANPATH="/usr/local/man:$MANPATH"
-
-# You may need to manually set your language environment
-# export LANG=en_US.UTF-8
-
-# Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
-
-# Compilation flags
-# export ARCHFLAGS="-arch x86_64"
-
-# ssh
-# export SSH_KEY_PATH="~/.ssh/rsa_id"
-
-# Set personal aliases, overriding those provided by oh-my-zsh libs,
-# plugins, and themes. Aliases can be placed here, though oh-my-zsh
-# users are encouraged to define aliases within the ZSH_CUSTOM folder.
-# For a full list of active aliases, run `alias`.
-#
-# Example aliases
-# alias zshconfig="mate ~/.zshrc"
-# alias ohmyzsh="mate ~/.oh-my-zsh"
-# 
-# Control Homeassistant
 alias hadown=curl -d '{"version": "'$1'"}' http://hassio/homeassistant/update
 alias haup=hassio homeassisant update
-alias halog=hassio homeassisant log
+alias halog=hassio homeassisant logs
 alias hastop=hassio homeassisant stop
 alias hastart=hassio homeassisant start
 alias harestart=hassio homeassisant restart
 alias hacheck=hassio homeassisant check
-
-# Control Supervisor
 alias supup=hassio supervisor update
-alias suplog=hassio supervisor log
-alias supstop=hassio supervisor stop
-alias supstart=hassio supervisor start
-alias suprestart=hassio supervisor restart
-
-# Control Host
+alias suplog=hassio supervisor logs
+alias supinfo=hassio supervisor info
+alias supreload=hassio supervisor reload
 alias hostup=hassio host update
-alias hostlog=hassio host log
-alias hoststop=hassio host stop
-alias hoststart=hassio host start
-alias hostrestart=hassio host reboot
+alias hostshut=hassio host shutdown
+alias hosthard=hassio host hardware
+alias hostreboot=hassio host reboot

--- a/ssh/rootfs/root/.zshrc
+++ b/ssh/rootfs/root/.zshrc
@@ -4,7 +4,9 @@ DISABLE_AUTO_UPDATE="true"
 COMPLETION_WAITING_DOTS="true"
 plugins=(extract git tmux nmap rsync)
 source $ZSH/oh-my-zsh.sh
-#alias hadown=curl -d '{"version": "'$1'"}' http://hassio/homeassistant/update
+hadown() {
+  curl -d '{"version": "'$1'"}' http://hassio/homeassistant/update
+}
 alias haup='hassio homeassistant update'
 alias halog='hassio homeassistant logs'
 alias hastop='hassio homeassistant stop'


### PR DESCRIPTION
Removed all the comments from .zshrc as they are not required and just make the file harder to read. 
Added aliases for all the hassio commands to make it simpler and easier to call
Added a function for downgrading so that people dont need to remember the syntax

downgrade function can be called like:
`hadown 0.59.1`
to update to latest version:
`haup`
to read logs
`halog`
`suplog`