### PR TITLE
Update docker image to use hassio-cli 1.3.0

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -33,7 +33,7 @@ RUN \
         git://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh \
     \
     && curl -L -s -o /usr/bin/hassio \
-        "https://github.com/home-assistant/hassio-cli/releases/download/1.2.1/hassio_${BUILD_ARCH}" \
+        "https://github.com/home-assistant/hassio-cli/releases/download/1.3.0/hassio_${BUILD_ARCH}" \
     \
     && sed -i -e "s/bin\/ash/bin\/zsh/" /etc/passwd \
     \


### PR DESCRIPTION
# Proposed Changes

> hassio-cli was updated 21 days ago to 1.3.0 and has some bug fixes that work in the regular ssh addon. This change updates hassio-cli to 1.3.0