### PR TITLE
Fixes #30 : Added 'less' package, which fixes bad git-diff colouring.

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -25,6 +25,7 @@ RUN \
         bind-tools=9.12.1_p2-r0 \
         bluez=5.49-r2 \
         git=2.18.0-r0 \
+        less=530-r0 \
         json-c=0.13.1-r0 \
         libwebsockets@legacy=2.4.0-r1 \
         libwebsockets-dev@legacy=2.4.0-r1 \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Install a more featured version of `less` alpine package to fix bad colouring when running `git diff`

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

#30 

https://github.com/home-assistant/hassio/issues/343