### PR TITLE
:books: Add limitation root with rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ automation:
   works when SSL is enabled.
 - When SFTP is enabled, the username MUST be set to `root`.
 - If you want to use rsync for file transfer, the username MUST be set to
-  `root` to let HA config foldfer be updated.
+  `root`.
 - The following error may occur in your add-on log, and can be safely ignored:
 
   ```txt

--- a/README.md
+++ b/README.md
@@ -359,6 +359,8 @@ automation:
 - My browser throws an `ERR_SSL_PROTOCOL_ERROR`. The OPEN WEB UI button only
   works when SSL is enabled.
 - When SFTP is enabled, the username MUST be set to `root`.
+- If you want to use rsync for file transfer, the username MUST be set to
+  `root` to let HA config foldfer be updated.
 - The following error may occur in your add-on log, and can be safely ignored:
 
   ```txt


### PR DESCRIPTION
# Proposed Changes

> Add in limitation the need to use `root` username with rsync. It's not obvious and I've try to make it work without `root` before having confirmation on the community forum

## Related Issues

> N/A

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/