### PR TITLE
Make HASSIO_TOKEN available for more shells in /etc/profile.d/hassio.sh

### DIFF
--- a/ssh/rootfs/etc/cont-init.d/user.sh
+++ b/ssh/rootfs/etc/cont-init.d/user.sh
@@ -5,7 +5,7 @@
 # ==============================================================================
 readonly -a DIRECTORIES=(addons backup config share ssl)
 readonly SSH_USER_PATH=/data/.ssh
-readonly ZSH_ENVIRONMENT_FILE=/root/.zshenv
+readonly HASSIO_PROFILE_D_FILE=/etc/profile.d/hassio.sh
 readonly ZSH_HISTORY_FILE=/root/.zsh_history
 readonly ZSH_HISTORY_PERSISTANT_FILE=/data/.zsh_history
 readonly GIT_CONFIG=/data/.gitconfig
@@ -27,7 +27,7 @@ chmod 600 "$ZSH_HISTORY_PERSISTANT_FILE" \
 ln -s -f "$ZSH_HISTORY_PERSISTANT_FILE" "$ZSH_HISTORY_FILE" \
     || bashio::exit.nok 'Failed linking the persistant ZSH history file'
 
-echo "export HASSIO_TOKEN=\"${HASSIO_TOKEN}\"" > "${ZSH_ENVIRONMENT_FILE}" \
+echo "export HASSIO_TOKEN=\"${HASSIO_TOKEN}\"" > "${HASSIO_PROFILE_D_FILE}" \
     || bashio::exit.nok 'Failed to export Hassio API token'
 
 # Sets up the users .ssh folder to be persistent


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Using /etc/profile.d/*.sh applies to more shells than ~/.zshenv

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

#108 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/