### PR TITLE
Upgrade add-on base image to 9.1.4

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.2
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.1.4
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -23,7 +23,7 @@ RUN \
         json-c-dev=0.15-r1 \
         libffi-dev=3.3-r2 \
         libuv-dev=1.40.0-r0 \
-        openssl-dev=1.1.1i-r0 \
+        openssl-dev=1.1.1j-r0 \
         python3-dev=3.8.7-r0 \
         zlib-dev=1.2.11-r3 \
     \
@@ -55,7 +55,7 @@ RUN \
         networkmanager=1.26.4-r0 \
         nmap=7.91-r0 \
         openssh=8.4_p1-r2 \
-        openssl=1.1.1i-r0 \
+        openssl=1.1.1j-r0 \
         pwgen=2.08-r1 \
         pulseaudio-utils=14.1-r0 \
         py3-pip=20.3.4-r0 \

--- a/ssh/build.json
+++ b/ssh/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.2",
-    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.2",
-    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.2",
-    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.2",
-    "i386": "ghcr.io/hassio-addons/base/i386:9.1.2"
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.1.4",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.1.4",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.1.4",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.1.4",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.1.4"
   }
 }


### PR DESCRIPTION
# Proposed Changes

Bumps add-on base image to 9.1.4:

https://github.com/hassio-addons/addon-base/releases/tag/v9.1.4

Additionally bumps openssl packages in order to be able to match upstream.