### PR TITLE
Add access to journald

### DIFF
--- a/ssh/config.json
+++ b/ssh/config.json
@@ -41,6 +41,7 @@
     "share:rw",
     "backup:rw"
   ],
+  "journald": true,
   "options": {
     "ssh": {
       "username": "hassio",


### PR DESCRIPTION
# Proposed Changes

This PR grands the add-on access to the journald log files from the host system. This can be helpful when debugging/chasing issues with the system.
