### PR TITLE
🔥 Remove hibp checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ well. Additionally, it comes out of the box with the following:
   - Many more security tweaks, _this addon passes all [ssh-audit] checks
     without warnings!_
     ![Result of SSH-Audit](images/ssh-audit.png)
-- Passwords are checked with HaveIBeenPwned using K-anonymity.
 - Comes with an SSH compatibility mode option to allow older clients to connect.
 - Support for Mosh allowing roaming and supports intermittent connectivity.
 - SFTP support is disabled by default but is user configurable.

--- a/ssh/.README.j2
+++ b/ssh/.README.j2
@@ -46,7 +46,6 @@ well. Additionally, it comes out of the box with the following:
   - Many more security tweaks, *this addon passes all [ssh-audit] checks
     without warnings!*
     ![Result of SSH-Audit][ssh-audit-image]
-- Passwords are checked with HaveIBeenPwned using K-anonymity.
 - Comes with an SSH compatibility mode option to allow older clients to connect.
 - Support for Mosh allowing roaming and supports intermittent connectivity.
 - SFTP support is disabled by default but is user configurable.

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -30,7 +30,6 @@ well. Additionally, it comes out of the box with the following:
   - Limits login attempts to hold off brute-force attacks better.
   - Many more security tweaks, _this addon passes all [ssh-audit] checks
     without warnings!_
-- Passwords are checked with HaveIBeenPwned using K-anonymity.
 - Comes with an SSH compatibility mode option to allow older clients to connect.
 - Support for Mosh allowing roaming and supports intermittent connectivity.
 - SFTP support is disabled by default but is user configurable.

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -231,14 +231,6 @@ Customize your shell environment even more with the `init_commands` option.
 Add one or more shell commands to the list, and they will be executed every
 single time this add-on starts.
 
-#### Option: `i_like_to_be_pwned`
-
-Adding this option to the add-on configuration allows to you bypass the
-HaveIBeenPwned password requirement by setting it to `true`.
-
-**Note**: _We STRONGLY suggest picking a stronger/safer password instead of
-using this option! USE AT YOUR OWN RISK!_
-
 ## Known issues and limitations
 
 - The add-on fails to start when a password that is listed by HaveIBeenPwned

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -84,4 +84,3 @@ schema:
     - str
   init_commands:
     - str
-  i_like_to_be_pwned: bool?

--- a/ssh/rootfs/etc/cont-init.d/ssh.sh
+++ b/ssh/rootfs/etc/cont-init.d/ssh.sh
@@ -52,12 +52,6 @@ then
     bashio::exit.nok
 fi
 
-# Require a secure password
-if bashio::config.has_value 'ssh.password' \
-    && ! bashio::config.true 'i_like_to_be_pwned'; then
-    bashio::config.require.safe_password 'ssh.password'
-fi
-
 # SFTP only works if the user is root
 if bashio::config.true 'ssh.sftp' \
     && ! bashio::config.equals 'ssh.username' 'root';


### PR DESCRIPTION
# Proposed Changes

This removes the `i_like_to_be_pwned` configuration parameter and HIBP checks.
This functionality is now part of the Supervisor itself, and no longer needed in the add-on.
