### PR TITLE
🔥 Remove homeassistant_cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ well. Additionally, it comes out of the box with the following:
 - Contains a sensible set of tools right out of the box: curl, Wget, RSync, GIT,
   Nmap, Mosquitto client, MariaDB/MySQL client, Awake (“wake on LAN”), Nano,
   Vim, tmux, and a bunch commonly used networking tools.
-- Has the Home Assistant CLI (`hass-cli`) command line tool pre-installed and
-  pre-configured.
 - Support executing commands inside using a Home Assistant service call, e.g.,
   for use with automations.
 

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -53,8 +53,6 @@ well. Additionally, it comes out of the box with the following:
 - Contains a sensible set of tools right out of the box: curl, Wget, RSync, GIT,
   Nmap, Mosquitto client, MariaDB/MySQL client, Awake (“wake on LAN”), Nano,
   Vim, tmux, and a bunch commonly used networking tools.
-- Has the Home Assistant CLI (`hass-cli`) command line tool pre-installed and
-  pre-configured.
 - Support executing commands inside using a Home Assistant service call, e.g.,
   for use with automations.
 

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -120,8 +120,6 @@ RUN \
         --find-links "https://wheels.home-assistant.io/alpine-3.14/${BUILD_ARCH}/" \
         -r /tmp/requirements.txt \
     \
-    && hass-cli completion bash > /usr/share/bash-completion/completions/hass-cli \
-    \
     && apk del --no-cache --purge .build-dependencies \
     \
     && find /usr/local \

--- a/ssh/requirements.txt
+++ b/ssh/requirements.txt
@@ -1,3 +1,2 @@
-homeassistant_cli==0.9.1
 pulsemixer==1.5.1
 yamllint==1.26.3


### PR DESCRIPTION
# Proposed Changes

Upgrades for this tool have been incompatible for some time now; and therefore has been removed.
