### PR TITLE
Preserve the SSH_AUTH_SOCK environment variable

### DIFF
--- a/ssh/rootfs/etc/sudoers.d/ssh-agent-env
+++ b/ssh/rootfs/etc/sudoers.d/ssh-agent-env
@@ -1,0 +1,1 @@
+Defaults env_keep += SSH_AUTH_SOCK


### PR DESCRIPTION
# Proposed Changes

Add `--preserve-env=SSH_AUTH_SOCK` to the `sudo` invocation that switches to `root` immediately upon login (from, e.g. `hassio` user)

N.b. it's fine to leave this in by default, since if `allow_agent_forwarding` is false, the agent won't work.

## Related Issues

fixes #367 SSH agent configuration isn't preserved
