### PR TITLE
⬆️ Upgrades Home Assistant CLI to v4.17.0

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -75,7 +75,7 @@ RUN \
         https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh \
     \
     && curl -L -s -o /usr/bin/ha \
-        "https://github.com/home-assistant/cli/releases/download/4.16.1/ha_${BUILD_ARCH}" \
+        "https://github.com/home-assistant/cli/releases/download/4.17.0/ha_${BUILD_ARCH}" \
     \
     && chmod a+x /usr/bin/ha \
     && ha completion > /usr/share/bash-completion/completions/ha \


### PR DESCRIPTION
# Proposed Changes

https://github.com/home-assistant/cli/releases/tag/4.17.0
