### PR TITLE
⬆️ Upgrades Home Assistant CLI to v4.19.0

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -75,7 +75,7 @@ RUN \
         https://github.com/robbyrussell/oh-my-zsh.git ~/.oh-my-zsh \
     \
     && curl -L -s -o /usr/bin/ha \
-        "https://github.com/home-assistant/cli/releases/download/4.18.0/ha_${BUILD_ARCH}" \
+        "https://github.com/home-assistant/cli/releases/download/4.19.0/ha_${BUILD_ARCH}" \
     \
     && chmod a+x /usr/bin/ha \
     && ha completion > /usr/share/bash-completion/completions/ha \


### PR DESCRIPTION
# Proposed Changes

Upgrades Home Assistant CLI to v4.19.0
