### PR TITLE
🪟 Set window title in bash prompt

### DIFF
--- a/ssh/rootfs/etc/profile.d/hassio.sh
+++ b/ssh/rootfs/etc/profile.d/hassio.sh
@@ -1,1 +1,4 @@
-export PS1="\W \$ "
+export PS1='\W $ '
+case "${TERM-}" in
+    rxvt*|vte*|xterm*) PS1='\[\e]0;\u@\h:\w\a\]'"$PS1" ;;
+esac


### PR DESCRIPTION
# Proposed Changes

With zsh, the window title is set to display the user, host, and path. This makes it happen for bash too, using the same format as it's with zsh.

The TERM cases where this is done come from Ubuntu 20.04 and CentOS 7 combined. (CentOS sets the title via `$PROMPT_COMMAND`, not `$PS1` though.)

## Related Issues

None that I know of.