### PR TITLE
⬆️ Upgrades mariadb-client to 10.6.9-r0

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -45,7 +45,7 @@ RUN \
         libltdl=2.4.7-r0 \
         libuv=1.44.1-r0 \
         libxml2-utils=2.9.14-r0 \
-        mariadb-client=10.6.8-r0 \
+        mariadb-client=10.6.9-r0 \
         mosh=1.3.2-r22 \
         mosquitto-clients=2.0.14-r1 \
         nano-syntax=6.3-r0 \


### PR DESCRIPTION
# Proposed Changes

Upgrades mariadb-client to 10.6.9-r0
