### PR TITLE
🚑 Fix ha CLI autocompletion

### DIFF
--- a/ssh/rootfs/root/.zshrc
+++ b/ssh/rootfs/root/.zshrc
@@ -94,4 +94,4 @@ source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zs
 # alias ohmyzsh="mate ~/.oh-my-zsh"
 
 # Home Assistant CLI
-source <(ha completion --zsh)
+source <(ha completion zsh) && compdef _ha ha


### PR DESCRIPTION
# Proposed Changes

Adjust and fix `ha` CLI autocompletion caused by the change in:

https://github.com/home-assistant/cli/pull/367
