### PR TITLE
Fix bash completion

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -78,7 +78,7 @@ RUN \
         "https://github.com/home-assistant/cli/releases/download/4.22.0/ha_${BUILD_ARCH}" \
     \
     && chmod a+x /usr/bin/ha \
-    && ha completion > /usr/share/bash-completion/completions/ha \
+    && ha completion bash > /usr/share/bash-completion/completions/ha \
     \
     && sed -i -e "s#bin/ash#bin/zsh#" /etc/passwd \
     \


### PR DESCRIPTION
# Proposed Changes

Bash completion is broken in the latest release. This PR fixes it.

```
~ $ ha <TAB> 
.bash_history  .config/       .lesshst       .ssh/          .viminfo       .zshrc         backup/        media/         ssl/           
.bash_profile  .gitconfig     .oh-my-zsh/    .tmux.conf     .vimrc         addons/        config/        share/
```

## Related Issues

#460 fixed completion for `zsh` but not for `bash`.