### PR TITLE
Fix bash; use hash mark in root prompt

### DIFF
--- a/ssh/rootfs/etc/profile.d/hassio.sh
+++ b/ssh/rootfs/etc/profile.d/hassio.sh
@@ -1,4 +1,9 @@
-export PS1='\W $ '
+export PS1='\W'
+if [ "${USER-}" = root ]; then
+    PS1="$PS1 # "
+else
+    PS1="$PS1 \$ "
+fi
 case "${TERM-}" in
     rxvt*|vte*|xterm*) PS1='\[\e]0;\u@\h:\w\a\]'"$PS1" ;;
 esac


### PR DESCRIPTION
# Proposed Changes

`#` for root, `$` for non-root is a long standing tradition in bash and some other shells. Presenting `$` for root is kind of dangerous as it causes incorrect assumptions about the powers at hand.

I don't know but I suppose `/etc/profile.d` snippets are loaded by zsh as well, but the zsh prompt looks quite different; I believe it gets rewritten later on on purpose. And maybe the hash vs dollar tradition isn't a thing for it in the first place, so this change should be good from that point of view.