### PR TITLE
Sync server `KexAlgorithms` with OpenSSH 9.1 and ssh-audit dev

### DIFF
--- a/ssh/rootfs/etc/ssh/sshd_config
+++ b/ssh/rootfs/etc/ssh/sshd_config
@@ -23,7 +23,7 @@ HostKey /data/ssh_host_ed25519_key
 # ===================
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
-KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
+KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
 
 # Authentication
 # ===================


### PR DESCRIPTION

# Proposed Changes

> (Describe the changes and rationale behind them)

```
(rec) +sntrup761x25519-sha512@openssh.com   -- kex algorithm to append
(rec) -diffie-hellman-group14-sha256        -- kex algorithm to remove
```

https://github.com/openssh/openssh-portable/blob/4922ac3be8a996780ef3dc220411da2e27c29d9c/sshd_config.5#L1045-L1050

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
