### PR TITLE
Specify server MACs and KexAlgos in terms of removals

### DIFF
--- a/ssh/rootfs/etc/ssh/sshd_config
+++ b/ssh/rootfs/etc/ssh/sshd_config
@@ -22,8 +22,8 @@ HostKey /data/ssh_host_ed25519_key
 # Cryptography
 # ===================
 Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com
-KexAlgorithms sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512
+MACs -hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128@openssh.com,umac-64-etm@openssh.com,umac-64@openssh.com
+KexAlgorithms -ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group14-sha256
 
 # Authentication
 # ===================


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

For easier maintenance on version changes and crosschecking with ssh-audit, self/intent-documenting.

Subtle MACs order difference before and after in terms of ssh-audit output:
```
 # message authentication code algorithms
-(mac) hmac-sha2-512-etm@openssh.com         -- [info] available since OpenSSH 6.2
-(mac) hmac-sha2-256-etm@openssh.com         -- [info] available since OpenSSH 6.2
 (mac) umac-128-etm@openssh.com              -- [info] available since OpenSSH 6.2
+(mac) hmac-sha2-256-etm@openssh.com         -- [info] available since OpenSSH 6.2
+(mac) hmac-sha2-512-etm@openssh.com         -- [info] available since OpenSSH 6.2
```

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
