### PR TITLE
Implement current ssh-audit dev client recommendations

### DIFF
--- a/ssh/rootfs/etc/ssh/ssh_config
+++ b/ssh/rootfs/etc/ssh/ssh_config
@@ -1,0 +1,50 @@
+#	$OpenBSD: ssh_config,v 1.35 2020/07/17 03:43:42 dtucker Exp $
+
+# This is the ssh client system-wide configuration file.  See
+# ssh_config(5) for more information.  This file provides defaults for
+# users, and the values can be changed in per-user configuration files
+# or on the command line.
+
+# Configuration data is parsed as follows:
+#  1. command line options
+#  2. user-specific file
+#  3. system-wide file
+# Any configuration value is only changed the first time it is set.
+# Thus, host-specific definitions should be at the beginning of the
+# configuration file, and defaults at the end.
+
+# Site-wide defaults for some commonly used options.  For a comprehensive
+# list of available options, their meanings and defaults, please see the
+# ssh_config(5) man page.
+
+#Host *
+#   ForwardAgent no
+#   ForwardX11 no
+#   PasswordAuthentication yes
+#   HostbasedAuthentication no
+#   GSSAPIAuthentication no
+#   GSSAPIDelegateCredentials no
+#   BatchMode no
+#   CheckHostIP yes
+#   AddressFamily any
+#   ConnectTimeout 0
+#   StrictHostKeyChecking ask
+#   IdentityFile ~/.ssh/id_rsa
+#   IdentityFile ~/.ssh/id_dsa
+#   IdentityFile ~/.ssh/id_ecdsa
+#   IdentityFile ~/.ssh/id_ed25519
+#   Port 22
+#   Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc
+#   MACs hmac-md5,hmac-sha1,umac-64@openssh.com
+#   EscapeChar ~
+#   Tunnel no
+#   TunnelDevice any:any
+#   PermitLocalCommand no
+#   VisualHostKey no
+#   ProxyCommand ssh -q -W %h:%p gateway.example.com
+#   RekeyLimit 1G 1h
+#   UserKnownHostsFile ~/.ssh/known_hosts.d/%k
+
+HostKeyAlgorithms -ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com
+KexAlgorithms -diffie-hellman-group14-sha256,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521
+MACs -hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128@openssh.com,umac-64-etm@openssh.com,umac-64@openssh.com


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

```
-(rec) -diffie-hellman-group14-sha256               -- kex algorithm to remove
-(rec) -ecdh-sha2-nistp256                          -- kex algorithm to remove
-(rec) -ecdh-sha2-nistp384                          -- kex algorithm to remove
-(rec) -ecdh-sha2-nistp521                          -- kex algorithm to remove
-(rec) -ecdsa-sha2-nistp256                         -- key algorithm to remove
-(rec) -ecdsa-sha2-nistp256-cert-v01@openssh.com    -- key algorithm to remove
-(rec) -ecdsa-sha2-nistp384                         -- key algorithm to remove
-(rec) -ecdsa-sha2-nistp384-cert-v01@openssh.com    -- key algorithm to remove
-(rec) -ecdsa-sha2-nistp521                         -- key algorithm to remove
-(rec) -ecdsa-sha2-nistp521-cert-v01@openssh.com    -- key algorithm to remove
-(rec) -hmac-sha1                                   -- mac algorithm to remove
-(rec) -hmac-sha1-etm@openssh.com                   -- mac algorithm to remove
-(rec) -hmac-sha2-256                               -- mac algorithm to remove
-(rec) -hmac-sha2-512                               -- mac algorithm to remove
-(rec) -sk-ecdsa-sha2-nistp256-cert-v01@openssh.com -- key algorithm to remove
-(rec) -sk-ecdsa-sha2-nistp256@openssh.com          -- key algorithm to remove
-(rec) -umac-128@openssh.com                        -- mac algorithm to remove
-(rec) -umac-64-etm@openssh.com                     -- mac algorithm to remove
-(rec) -umac-64@openssh.com                         -- mac algorithm to remove
```

Build not tested, I'm assuming everything in `ssh/rootfs` gets copied over.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
