### PR TITLE
Allow to disable tmux

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -208,6 +208,11 @@ The add-on has ZSH pre-installed and configured as the default shell.
 However, ZSH might not be your preferred choice. By setting this option to
 `false`, you will disable ZSH and the add-on will fallback to Bash instead.
 
+#### Option: `tmux`
+
+By default, the terminal Web UI uses [tmux][tmux] which can be disabled by
+setting this option to `false`.
+
 #### Option: `share_sessions`
 
 By default, the terminal session between the web client and SSH is shared.
@@ -322,4 +327,5 @@ SOFTWARE.
 [releases]: https://github.com/hassio-addons/addon-ssh/releases
 [semver]: https://semver.org/spec/v2.0.0.html
 [ssh-audit]: https://github.com/jtesta/ssh-audit
+[tmux]: https://github.com/tmux/tmux
 [zsh]: https://en.wikipedia.org/wiki/Z_shell

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -65,6 +65,7 @@ options:
     allow_remote_port_forwarding: false
     allow_tcp_forwarding: false
   zsh: true
+  tmux: true
   share_sessions: false
   packages: []
   init_commands: []
@@ -81,6 +82,7 @@ schema:
     allow_remote_port_forwarding: bool
     allow_tcp_forwarding: bool
   zsh: bool
+  tmux: bool
   share_sessions: bool
   packages:
     - str

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
@@ -24,9 +24,15 @@ options+=(-i hassio)
 ingress_port=$(bashio::addon.ingress_port)
 options+=(-p "${ingress_port}")
 
-ttyd_command=(tmux -u new -A -s homeassistant zsh -l)
-if ! bashio::config.true "zsh"; then
-    ttyd_command=(tmux -u new -A -s homeassistant bash -l)
+ttyd_command=()
+if bashio::config.true "tmux"; then
+    ttyd_command+=(tmux -u new -A -s homeassistant)
+fi
+
+if bashio::config.true "zsh"; then
+    ttyd_command+=(zsh -l)
+else
+    ttyd_command+=(bash -l)
 fi
 
 # Change working directory


### PR DESCRIPTION
# Proposed Changes

I can't express how much I hate interacting with tmux. It brings me zero benefits and yet a lot of pain.

To say the least, it completely breaks the experience when using Android to interact with the terminal Web UI.

This adds a new option to allow disabling tmux.

## Related Issues

None.
