### PR TITLE
Rename add-on to Advanced SSH & Web Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 
 [![GitHub Release][releases-shield]][releases]
 ![Project Stage][project-stage-shield]
@@ -41,8 +41,8 @@ usability, flexibility and also provides access using a web interface.
 
 ## WARNING
 
-The SSH & Web Terminal add-on is very powerful and gives you access to almost
-all tools and hardware of your system.
+The advanced SSH & Web Terminal add-on is very powerful and gives you access
+to almost all tools and hardware of your system.
 
 While this add-on is created and maintained with care and with security in mind,
 in the wrong or inexperienced hands, it could damage your system.

--- a/ssh/.README.j2
+++ b/ssh/.README.j2
@@ -1,4 +1,4 @@
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 
 [![Release][release-shield]][release] ![Project Stage][project-stage-shield] ![Project Maintenance][maintenance-shield]
 
@@ -26,8 +26,8 @@ usability, flexibility and also provides access using a web interface.
 
 ## WARNING
 
-The SSH & Web Terminal add-on is a really powerful and gives you virtually
-access to all tools and almost all hardware of your system.
+The advanced SSH & Web Terminal add-on is a really powerful and gives you
+virtually access to all tools and almost all hardware of your system.
 
 While this add-on is created and maintained with care and with security in mind,
 in the wrong or inexperienced hands, it could damage your system.

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -1,4 +1,4 @@
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 
 This add-on allows you to log in to your Home Assistant instance using
 SSH or a Web Terminal, giving you to access your folders and
@@ -11,8 +11,8 @@ usability, flexibility and also provides access using a web interface.
 
 ## WARNING
 
-The SSH & Web Terminal add-on is very powerful and gives you access to almost
-all tools and hardware of your system.
+The advanced SSH & Web Terminal add-on is very powerful and gives you access
+to almost all tools and hardware of your system.
 
 While this add-on is created and maintained with care and with security in mind,
 in the wrong or inexperienced hands, it could damage your system.
@@ -68,8 +68,8 @@ comparison to installing any other Home Assistant add-on.
 
 1. Click the "Install" button to install the add-on.
 1. Configure the `username` and `password`/`authorized_keys` options.
-1. Start the "SSH & Web Terminal" add-on.
-1. Check the logs of the "SSH & Web Terminal" add-on to see if everything
+1. Start the "Advanced SSH & Web Terminal" add-on.
+1. Check the logs of the "Advanced SSH & Web Terminal" add-on to see if everything
    went well.
 
 ## Configuration

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -1,11 +1,10 @@
 ---
-name: SSH & Web Terminal
+name: Advanced SSH & Web Terminal
 version: dev
 slug: ssh
-description: SSH & Web Terminal access to your Home Assistant instance
+description: A supercharged SSH & Web Terminal access to your Home Assistant instance
 url: https://github.com/hassio-addons/addon-ssh
 codenotary: codenotary@frenck.dev
-advanced: true
 startup: services
 ingress: true
 ingress_port: 0

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-docker/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-docker/run
@@ -2,7 +2,7 @@
 # shellcheck shell=bash
 # shellcheck disable=SC2207
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # Enables Docker by moving the Docker executable in place.
 # ==============================================================================
 if bashio::var.false "$(bashio::addon.protected)"; then

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-mosquitto/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-mosquitto/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # Pre-configures the Mosquitto clients, if the service is available
 # ==============================================================================
 declare host

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-mysql/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-mysql/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # Pre-configures the MySQL clients, if the service is available
 # ==============================================================================
 declare host

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # Configures the SSH daemon
 # ==============================================================================
 readonly SSH_AUTHORIZED_KEYS_PATH=/etc/ssh/authorized_keys

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # Executes configured customizations & persists user settings
 # ==============================================================================
 readonly -a DIRECTORIES=(addons backup config media share ssl)

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/sshd/finish
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/sshd/finish
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # Take down the S6 supervision tree when the SSH daemon fails
 # ==============================================================================
 declare exit_code

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/sshd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/sshd/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # Starts the SSH service
 # ==============================================================================
 declare -a options

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/finish
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/finish
@@ -1,6 +1,6 @@
 #!/command/with-contenv bashio
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # Take down the S6 supervision tree when the ttyd daemon fails
 # ==============================================================================
 declare exit_code

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
@@ -1,7 +1,7 @@
 #!/command/with-contenv bashio
 # shellcheck shell=bash
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # Runs the ttyd daemon
 # ==============================================================================
 declare ttyd_command

--- a/ssh/rootfs/usr/local/bin/docker
+++ b/ssh/rootfs/usr/local/bin/docker
@@ -1,6 +1,6 @@
 #!/command/with-contenv bashio
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # This script gives the user instructions on how to enable Docker access.
 # ==============================================================================
 bashio::log.yellow "PROTECTION MODE ENABLED!"
@@ -12,7 +12,7 @@ bashio::log.yellow ""
 bashio::log.yellow "Steps:"
 bashio::log.yellow " - Go to the Configuration Panel."
 bashio::log.yellow " - Enter the 'Add-ons, Backups & Supervisor' menu."
-bashio::log.yellow " - Click on the SSH & Web Terminal add-on."
+bashio::log.yellow " - Click on the Advanced SSH & Web Terminal add-on."
 bashio::log.yellow " - Set the 'Protection mode' switch to off."
 bashio::log.yellow " - Restart the add-on."
 bashio::log.yellow ""

--- a/ssh/rootfs/usr/local/bin/reboot
+++ b/ssh/rootfs/usr/local/bin/reboot
@@ -1,6 +1,6 @@
 #!/command/with-contenv bashio
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # This script overrides the reboot command to reboot the host machine.
 # ==============================================================================
 bashio::host.reboot

--- a/ssh/rootfs/usr/local/bin/shutdown
+++ b/ssh/rootfs/usr/local/bin/shutdown
@@ -1,6 +1,6 @@
 #!/command/with-contenv bashio
 # ==============================================================================
-# Home Assistant Community Add-on: SSH & Web Terminal
+# Home Assistant Community Add-on: Advanced SSH & Web Terminal
 # This script overrides the shutdown command to shutdown the host machine.
 # ==============================================================================
 bashio::host.shutdown


### PR DESCRIPTION
# Proposed Changes

The naming of this add-on often needs to be clarified with the official core add-on. While they are similar, the community version offers more capabilities and access.

Initially, the Core version didn't carry a web terminal. Hence the name in the past was different. Renaming it to `Advanced SSH & Web Terminal`, will provide an additional difference in naming and functionality.


