### PR TITLE
🚑 Move env setup after folder creation

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -52,9 +52,6 @@ echo "export SUPERVISOR_TOKEN=\"${SUPERVISOR_TOKEN}\"" \
     >> "${HOME_ASSISTANT_PROFILE_D_FILE}" \
         || bashio::exit.nok 'Failed to export Supervisor API token'
 
-echo "SUPERVISOR_TOKEN=${SUPERVISOR_TOKEN}" > /data/.ssh/environment \
-    || bashio::exit.nok 'Failed to set Supervisor API token in env'
-
 # Sets up the users .ssh folder to be persistent
 if ! bashio::fs.directory_exists "${SSH_USER_PATH}"; then
     mkdir -p "${SSH_USER_PATH}" \
@@ -65,6 +62,9 @@ if ! bashio::fs.directory_exists "${SSH_USER_PATH}"; then
             'Failed setting permissions on persistent .ssh folder'
 fi
 ln -s "${SSH_USER_PATH}" ~/.ssh
+
+echo "SUPERVISOR_TOKEN=${SUPERVISOR_TOKEN}" > /data/.ssh/environment \
+    || bashio::exit.nok 'Failed to set Supervisor API token in env'
 
 # Sets up the user .gitconfig file to be persistent
 if ! bashio::fs.file_exists "${GIT_CONFIG}"; then


### PR DESCRIPTION
# Proposed Changes

Move Environment file setup after the folder config, tested and should work ok.  I believe that the original testing is likely to do with using a password rather than key.

## Related Issues

Should fix #551 fix #552

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
