### PR TITLE
Make ttyd writable

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
@@ -20,6 +20,9 @@ fi
 # Listen on Supervisor interface only
 options+=(-i hassio)
 
+# We want to be able to use the terminal
+options+=(--writable)
+
 # Get assigned Ingress port
 ingress_port=$(bashio::addon.ingress_port)
 options+=(-p "${ingress_port}")


### PR DESCRIPTION
# Proposed Changes

SSIA, the latest ttyd makes the terminal read-only by default. However, our use case it to actually being able to type into it :)

This PR makes the add-on compatible with the latest ttyd
