### PR TITLE
Fix unbound variable in log warning message

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -21,9 +21,9 @@ done
 
 # Some links to old locations, to not mess with the user's muscle memory
 ln -s "/homeassistant" "/config" \
-    || bashio::log.warning "Failed linking common directory: ${dir}"
+    || bashio::log.warning "Failed linking common directory: /config"
 ln -s "/homeassistant" "${HOME}/config" \
-    || bashio::log.warning "Failed linking common directory: ${dir}"
+    || bashio::log.warning "Failed linking common directory: ${HOME}/config"
 
 # Sets up ZSH or Bash shell history
 if bashio::config.true "zsh"; then


### PR DESCRIPTION
# Proposed Changes

`${dir}` doesn't belong in this message.

<img src="https://media0.giphy.com/media/26tn8cc5IQjkWpJhm/giphy.gif"/>