### PR TITLE
Disable the chacha20-poly1305@openssh.com cipher, CVE-2023-48795

### DIFF
--- a/ssh/rootfs/etc/ssh/sshd_config
+++ b/ssh/rootfs/etc/ssh/sshd_config
@@ -21,7 +21,7 @@ HostKey /data/ssh_host_ed25519_key
 
 # Cryptography
 # ===================
-Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 MACs -hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128@openssh.com,umac-64-etm@openssh.com,umac-64@openssh.com
 KexAlgorithms -ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group14-sha256
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Disable the `chacha20-poly1305@openssh.com` cipher to address [CVE-2023-48795](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-48795).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
