### PR TITLE
Disable tmux mouse mode when running under ttyd

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
@@ -35,5 +35,8 @@ fi
 # Change working directory
 cd /root || bashio::exit.nok 'Unable to change working directory'
 
+# Set environment so that we know if we're running under ttyd
+export TTYD=1
+
 # Run the ttyd daemon
 exec ttyd "${options[@]}" "${ttyd_command[@]}"

--- a/ssh/rootfs/root/.tmux.conf
+++ b/ssh/rootfs/root/.tmux.conf
@@ -8,7 +8,9 @@ set -g status-fg white
 set -g status-bg blue
 set -g status-left ''
 set -g status-right '%a %m-%d %H:%M'
+if-shell '[ -z "$TTYD" ]' {
 set -g mouse on
+}
 unbind C-b
 set-option -g prefix C-a
 bind-key C-a send-prefix


### PR DESCRIPTION
# Proposed Changes

Set a `TTYD` environment variable for the ttyd daemon and disable mouse mode in tmux if `$TTYD` is set.

## Related Issues

Fixes #624 