### PR TITLE
Don't attempt to use xclip when X is not available

### DIFF
--- a/ssh/rootfs/root/.tmux.conf
+++ b/ssh/rootfs/root/.tmux.conf
@@ -24,5 +24,7 @@ bind -n M-Right select-pane -R
 bind -n M-Up select-pane -U
 bind -n M-Down select-pane -D
 set -s escape-time 0
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard -i"
-bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard -i"
+if-shell '[ -n "$DISPLAY" ]' {
+    bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard -i"
+    bind-key -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard -i"
+}


### PR DESCRIPTION
xclip needs access to your $DISPLAY, so if it's not set, don't try to use it.

Fixes #719 