### PR TITLE
Include procps by default for Visual Studio Code

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -255,8 +255,11 @@ Setting the following parameters as is shown will allow you to connect to
 your Home Assistant instance using VSCode Remote - SSH:
 
 ```yaml
-allow_remote_port_forwarding: true
-allow_tcp_forwarding: true
+ssh:
+  allow_remote_port_forwarding: true
+  allow_tcp_forwarding: true
+packages:
+  - procps
 ```
 
 ## Support

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -258,8 +258,6 @@ your Home Assistant instance using VSCode Remote - SSH:
 ssh:
   allow_remote_port_forwarding: true
   allow_tcp_forwarding: true
-packages:
-  - procps
 ```
 
 ## Support

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -59,6 +59,7 @@ RUN \
         nmap=7.94-r0 \
         openssh=9.6_p1-r0 \
         openssl=3.1.4-r6 \
+        procps=4.0.4-r0 \
         pwgen=2.08-r3 \
         pulseaudio-utils=16.1-r11 \
         py3-pip=23.3.1-r0 \


### PR DESCRIPTION
# Proposed Changes

Seems like the `ps` command included in Alpine is not enough anymore.
~~Adding this to the documentation, but maybe it makes more sense to have it in the Dockerfile?~~
Adding `procps` to the Dockerfile, so that's included and Visual Studio Code remote-ssh can connect out-of-the-box

## Related Issues

Fixes https://github.com/hassio-addons/addon-ssh/issues/722
