### PR TITLE
Add build time dependencies to successfully install the pip3 homeassistant-cli package

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -28,6 +28,9 @@ RUN \
         openssl-dev=3.1.4-r6 \
         python3-dev=3.11.9-r0 \
         zlib-dev=1.3.1-r0 \
+        python3-dev \
+        libc-dev \
+        gcc \
     \
     && apk add --no-cache \
         ack=3.7.0-r1 \

--- a/ssh/requirements.txt
+++ b/ssh/requirements.txt
@@ -1,2 +1,3 @@
 pulsemixer==1.5.1
 yamllint==1.35.1
+homeassistant-cli==0.9.6


### PR DESCRIPTION
# Proposed Changes

Add build time dependencies to successfully install the pip3 homeassistant-cli package - https://github.com/home-assistant-ecosystem/home-assistant-cli. 

This package is very handy to allow management of many additional aspects of home assistant from a cli interface. It's a great way to bulk rename entities for example using bash scripting and for loops, examples here - https://community.home-assistant.io/t/bulk-edit-for-entities/289593

## Related Issues

#728 
