### PR TITLE
Change default shell from /bin/ash to /bin/sh

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -84,7 +84,7 @@ RUN \
     && chmod a+x /usr/bin/ha \
     && ha completion bash > /usr/share/bash-completion/completions/ha \
     \
-    && sed -i -e "s#bin/ash#bin/zsh#" /etc/passwd \
+    && sed -i -e "s#bin/sh#bin/zsh#" /etc/passwd \
     \
     && git clone --branch "v4.3.3" --depth=1 \
         https://github.com/warmcat/libwebsockets.git /tmp/libwebsockets \


### PR DESCRIPTION
# Proposed Changes

Change default shell from /bin/ash to /bin/sh

## Related Issues

#744 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the SSH Dockerfile to use `zsh` instead of `sh` for the default shell environment. This change affects the shell experience by providing enhanced features and a more user-friendly interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->