### PR TITLE
Specify /bin/zsh when creating a new user

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -99,7 +99,7 @@ username=$(bashio::string.lower "${username}")
 if [[ "${username}" != "root" ]]; then
 
     # Create an user account
-    adduser -D "${username}" -s "/bin/sh" \
+    adduser -D "${username}" -s "/bin/zsh" \
         || bashio::exit.nok 'Failed creating the user account'
 
     # Add new user to the wheel group


### PR DESCRIPTION
This way if not asking for zsh
ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
In the "# Set up Bash" section will update the user shell to bash as well as root.

# Proposed Changes

> I wasn't using this addon prior to the change from /bin/ash to /bin/sh, I'm assuming the new user would have been assigned zsh (and changed to bash if the config has zsh set to false).
Maybe it is desired to keep using a fast starting sh since the default .profile is to change the user to root anyway.  If that's the case disregard.

## Related Issues
> Change default shell from /bin/ash to /bin/sh #747

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Default shell for newly created user accounts changed to Zsh for a more feature-rich command-line experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->