### PR TITLE
sudo sftp

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -137,9 +137,6 @@ you have authenticated. Using `root` as the username is possible, but not
 recommended. Usernames will be converted to lower case as per recommended
 practises.
 
-**Note**: _Due to limitations, you will need to set this option to `root` in
-order to be able to enable the SFTP capabilities._
-
 #### Option `ssh`: `password`
 
 Sets the password to log in with. Leaving it empty would disable the possibility
@@ -160,10 +157,7 @@ about using public/private key pairs and how to create them.
 #### Option `ssh`: `sftp`
 
 When set to `true` the addon will enable SFTP support on the SSH daemon.
-Please only enable it when you plan on using it.
-
-**Note**: _Due to limitations, you will need to set the username to `root` in
-order to be able to enable the SFTP capabilities._
+Please only enable it when you plan on using it (sshfs also requires SFTP).
 
 #### Option `ssh`: `compatibility_mode`
 
@@ -232,9 +226,8 @@ single time this add-on starts.
 
 ## Known issues and limitations
 
-- When SFTP is enabled, the username MUST be set to `root`.
-- If you want to use rsync for file transfer, the username MUST be set to
-  `root`.
+- If you want to use rsync for writing files, add the argument `--rsync-path="/usr/bin/sudo /usr/bin/rsync" ` to rsync as most files are writable only by root.
+- Alternatively set the username to `root`.
 
 ## Changelog & Releases
 

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -227,7 +227,7 @@ single time this add-on starts.
 ## Known issues and limitations
 
 - If you want to use rsync for writing files, add the argument `--rsync-path="/usr/bin/sudo /usr/bin/rsync" ` to rsync as most files are writable only by root.
-- Alternatively set the username to `root`.
+- Alternatively, set the username to `root`.
 
 ## Changelog & Releases
 

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -53,21 +53,6 @@ then
     bashio::exit.nok
 fi
 
-# SFTP only works if the user is root
-if bashio::config.true 'ssh.sftp' \
-    && ! bashio::config.equals 'ssh.username' 'root';
-then
-    bashio::log.fatal
-    bashio::log.fatal 'You have enabled SFTP using the "ssh.sftp" add-on'
-    bashio::log.fatal 'option. Unfortunately, this requires "ssh.username"'
-    bashio::log.fatal 'to be "root".'
-    bashio::log.fatal
-    bashio::log.fatal 'Please change "ssh.username" to "root" or disable'
-    bashio::log.fatal 'SFTP by setting "ssh.sftp" to false.'
-    bashio::log.fatal
-    bashio::exit.nok
-fi
-
 # Warn about password login
 if bashio::config.has_value 'ssh.password'; then
     bashio::log.warning
@@ -134,6 +119,13 @@ sed -i "s/Port\\ .*/Port\\ ${port}/" "${SSH_CONFIG_PATH}" \
 # SFTP access
 if bashio::config.true 'ssh.sftp'; then
     sed -i '/Subsystem sftp/s/^#//g' "${SSH_CONFIG_PATH}"
+    if [[ "${username}" != "root" ]]; then
+        # The configuration files a user is interested in are writable
+        # only by root and aren't accessible if logging in not as root.
+        # Run sftp-server under sudo just like .profile so it can modify
+        # them.
+        sed -i "s#/usr/lib/ssh/sftp-server#/usr/bin/sudo /usr/lib/ssh/sftp-server#" "${SSH_CONFIG_PATH}"
+    fi
     bashio::log.notice 'SFTP access is enabled'
 fi
 


### PR DESCRIPTION
# Proposed Changes

No longer require root for SFTP while allowing the user to write to the configuration files that only are writable by root, by running sftp-server under sudo.  Okay, so I didn't want to have to specify the user name (and especially not specify root), and sshfs to let me modify the configuration files on my desktop.

"SFTP only works if the user is root"
sftp runs just fine when it isn't root, it just can't write to the Home Assistant files because they are owned by root.  If that's what the warning is about, and why .profile is doing sudo -i, then likewise run sftp-server under sudo.
This helps to resolve the moral dilemma of one part of the documentation saying don't set username to root because many hack attempts will target it, and another part saying to run sftp you must be root.

Ideally Docker would allow the root user in the container to be mapped to a nobody outside of the container and the first adduser id 1000 be mapped to root outside of the container.  That way inside the container most users can remain the non-root user and see all the configuration files as owned by then.  I'm newer to docker, so I don't know if that's possible by an add-on in a Home Assistant OS.

## Related Issues

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for enabling SFTP capabilities, recommending to only enable SFTP when needed.
  - Introduced alternative methods for using `rsync` by specifying arguments or setting the username to `root`.

- **Chores**
  - Adjusted SFTP configuration to run under `sudo` when the username is not "root," allowing modification of configuration files.
  - Added readonly variables for various configuration files and created symbolic links to persistently link these files to `/data/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->