### PR TITLE
Upgrade openssh version to patch CVE-2024-6387

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -57,7 +57,7 @@ RUN \
         net-tools=2.10-r3 \
         networkmanager-cli=1.46.0-r0 \
         nmap=7.95-r0 \
-        openssh=9.7_p1-r3 \
+        openssh=9.8_p1-r0 \
         openssl=3.3.1-r0 \
         procps-ng=4.0.4-r0 \
         pwgen=2.08-r3 \


### PR DESCRIPTION
# Proposed Changes

Vulnurability found in openssh. This changes will patch it
Details can be found in the Qualys advisory at https://www.qualys.com/2024/07/01/cve-2024-6387/regresshion.txt

This PR should be merged once this PR from alpine will be merged: https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/68482



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `openssh` version from `9.7_p1-r3` to `9.8_p1-r0` in Dockerfile for enhanced security and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->