### PR TITLE
/bin/zsh bu Default

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -99,7 +99,7 @@ username=$(bashio::string.lower "${username}")
 if [[ "${username}" != "root" ]]; then
 
     # Create an user account
-    adduser -D "${username}" -s "/bin/sh" \
+    adduser -D "${username}" -s "/bin/zsh" \
         || bashio::exit.nok 'Failed creating the user account'
 
     # Add new user to the wheel group


### PR DESCRIPTION
# Proposed Changes

> from /bin/sh to /bin/zsh by Default

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default shell for non-root users from `/bin/sh` to `/bin/zsh` to enhance user experience with more features and a better interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->