### PR TITLE
Remove networkmanager-cli from installed packages

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -55,7 +55,6 @@ RUN \
         nano=8.0-r0 \
         ncurses=6.4_p20240420-r0 \
         net-tools=2.10-r3 \
-        networkmanager-cli=1.46.0-r0 \
         nmap=7.95-r0 \
         openssh=9.7_p1-r4 \
         openssl=3.3.1-r1 \


### PR DESCRIPTION
# Proposed Changes

Using nmcli from the SSH add-on is an unsupported way of adjusting network configuration in HA OS, and the mismatch of versions of the NetworkManager in the OS and nmcli in the add-on leads to errors that even make it impossible to use it. Having nmcli bundled in the SSH terminal add-on (even the unofficial one) makes users think this is somehow the correct and supported way of configuring advanced networking features.

Remove the package from the default set of installed software. Correct way to handle network configuration in HA OS is to use `ha network` command set, and if there's any functionality missing, open feature requests for that.

## Related Issues

Just a sample of some recent ones:

- https://github.com/home-assistant/operating-system/issues/3396
- https://github.com/home-assistant/operating-system/issues/3453
- https://github.com/home-assistant/operating-system/issues/3461



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Removed `networkmanager-cli` package from SSH Dockerfile to streamline the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->