### PR TITLE
⬆️ Update home-assistant/cli to v4.35.0

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -13,7 +13,7 @@ COPY requirements.txt /tmp/
 
 # Setup base
 ARG BUILD_ARCH=amd64
-ARG HA_CLI_VERSION="4.34.0"
+ARG HA_CLI_VERSION="4.35.0"
 ARG TTYD_VERSION="1.7.7"
 # hadolint ignore=DL3003,DL3042
 RUN \


### PR DESCRIPTION
# Proposed Changes

Bump HA CLI to latest version.

Fixes #758

## Related Issues

- https://github.com/hassio-addons/addon-ssh/issues/758


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the `HA_CLI_VERSION` in the Dockerfile for the SSH service from `4.34.0` to `4.35.0`. This ensures compatibility with the latest version of the HA CLI tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->