### PR TITLE
Synchronize the Features list across all documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,14 @@ well. Additionally, it comes out of the box with the following:
   - Limits login attempts to hold off brute-force attacks better.
   - Many more security tweaks, _this addon passes all [ssh-audit] checks
     without warnings!_
-    ![Result of SSH-Audit](images/ssh-audit.png)
+    ![Result of SSH-Audit][ssh-audit-image]
 - Comes with an SSH compatibility mode option to allow older clients to connect.
 - Support for Mosh allowing roaming and supports intermittent connectivity.
 - SFTP support is disabled by default but is user configurable.
 - Compatible if Home Assistant was installed via the generic Linux installer.
 - Username is configurable, so `root` is no longer mandatory.
 - Persists custom SSH client settings & keys between add-on restarts
+- Log levels for allowing you to triage issues easier.
 - Hardware access to your audio, uart/serial devices and GPIO pins.
 - Runs with more privileges, allowing you to debug and test more situations.
 - Has access to the dbus of the host system.
@@ -79,13 +80,9 @@ well. Additionally, it comes out of the box with the following:
 - [ZSH][zsh] as its default shell. Easier to use for the beginner, more advanced
   for the more experienced user. It even comes preloaded with
   ["Oh My ZSH"][ohmyzsh], with some plugins enabled as well.
-- Bash: If ZSH is not your cup of tea, Bash can be enabled again, which
-  includes Bash completion for both the Core CLI and the Home Assistant CLI.
 - Contains a sensible set of tools right out of the box: curl, Wget, RSync, GIT,
   Nmap, Mosquitto client, MariaDB/MySQL client, Awake (“wake on LAN”), Nano,
   Vim, tmux, and a bunch commonly used networking tools.
-- Support executing commands inside using a Home Assistant service call, e.g.,
-  for use with automations.
 
 ## Support
 
@@ -183,5 +180,6 @@ SOFTWARE.
 [releases]: https://github.com/hassio-addons/addon-ssh/releases
 [repository]: https://github.com/hassio-addons/repository
 [semver]: http://semver.org/spec/v2.0.0.htm
+[ssh-audit-image]: images/ssh-audit.png
 [ssh-audit]: https://github.com/jtesta/ssh-audit
 [zsh]: https://en.wikipedia.org/wiki/Z_shell

--- a/ssh/.README.j2
+++ b/ssh/.README.j2
@@ -43,8 +43,8 @@ well. Additionally, it comes out of the box with the following:
   - Only allows login by the configured user, even if more users are created.
   - Only uses known secure ciphers and algorithms.
   - Limits login attempts to hold off brute-force attacks better.
-  - Many more security tweaks, *this addon passes all [ssh-audit] checks
-    without warnings!*
+  - Many more security tweaks, _this addon passes all [ssh-audit] checks
+    without warnings!_
     ![Result of SSH-Audit][ssh-audit-image]
 - Comes with an SSH compatibility mode option to allow older clients to connect.
 - Support for Mosh allowing roaming and supports intermittent connectivity.

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -30,12 +30,14 @@ well. Additionally, it comes out of the box with the following:
   - Limits login attempts to hold off brute-force attacks better.
   - Many more security tweaks, _this addon passes all [ssh-audit] checks
     without warnings!_
+    ![Result of SSH-Audit][ssh-audit-image]
 - Comes with an SSH compatibility mode option to allow older clients to connect.
 - Support for Mosh allowing roaming and supports intermittent connectivity.
 - SFTP support is disabled by default but is user configurable.
 - Compatible if Home Assistant was installed via the generic Linux installer.
 - Username is configurable, so `root` is no longer mandatory.
 - Persists custom SSH client settings & keys between add-on restarts
+- Log levels for allowing you to triage issues easier.
 - Hardware access to your audio, uart/serial devices and GPIO pins.
 - Runs with more privileges, allowing you to debug and test more situations.
 - Has access to the dbus of the host system.
@@ -48,13 +50,9 @@ well. Additionally, it comes out of the box with the following:
 - [ZSH][zsh] as its default shell. Easier to use for the beginner, more advanced
   for the more experienced user. It even comes preloaded with
   ["Oh My ZSH"][ohmyzsh], with some plugins enabled as well.
-- Bash: If ZSH is not your cup of tea, Bash can be enabled again, which
-  includes Bash completion for both the Core CLI and the Home Assistant CLI.
 - Contains a sensible set of tools right out of the box: curl, Wget, RSync, GIT,
   Nmap, Mosquitto client, MariaDB/MySQL client, Awake (“wake on LAN”), Nano,
   Vim, tmux, and a bunch commonly used networking tools.
-- Support executing commands inside using a Home Assistant service call, e.g.,
-  for use with automations.
 
 ## Installation
 
@@ -322,5 +320,6 @@ SOFTWARE.
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/addon-ssh/releases
 [semver]: https://semver.org/spec/v2.0.0.html
+[ssh-audit-image]: https://github.com/hassio-addons/addon-ssh/raw/main/images/ssh-audit.png
 [ssh-audit]: https://github.com/jtesta/ssh-audit
 [zsh]: https://en.wikipedia.org/wiki/Z_shell


### PR DESCRIPTION
This commit synchronizes the README.md and DOCS.md file's Feature list to the list provided in .README.j2

# Proposed Changes

When I was looking into this repo instead of the core addon, I was looking for something that I could use to automate a command to dump the backup info to the backup directory as part of my nightly backup automation.

I ended up on this Github and reading the README.md file and saw the entry in the Features header:

> Support executing commands inside using a Home Assistant service call, e.g.,
  for use with automations.

I then spent too long trying to figure out how to accomplish that, before eventually learning that this feature was removed in v10 of this addon.

Diving into it a little deeper I learned that this feature is not present on the features list presented when installing the add-on (if only I had read that one clearer).

So this PR synchronizes the list of features provided on the Add-on documentation page with the list of features given in the `README.md` and `DOCS.md` file. Hopefully saving people like me who end up on the GitHub a little bit of confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation of the SSH add-on's features for better clarity.
	- Added configurable log levels to aid in troubleshooting and issue triage.
	- Updated image reference format for SSH audit results to improve organization.
	- Removed outdated information regarding Bash as an alternative shell option.
	- Streamlined content to focus on core functionalities and available tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->