### PR TITLE
Revert "Specify /bin/zsh when creating a new user (#755)"

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -99,7 +99,7 @@ username=$(bashio::string.lower "${username}")
 if [[ "${username}" != "root" ]]; then
 
     # Create an user account
-    adduser -D "${username}" -s "/bin/zsh" \
+    adduser -D "${username}" -s "/bin/sh" \
         || bashio::exit.nok 'Failed creating the user account'
 
     # Add new user to the wheel group


### PR DESCRIPTION
This reverts commit 7fd5170332d93f51530d519a00e93e85c75818fd.

# Proposed Changes

> This reverts #755, which introduced a bug preventing the user from switching to root after login. I can see that that PR was intended to fix #788, but there ought to be a proper fix in the way of utilizing the `zsh` configuration option rather than forcing the default shell to be `zsh`. If indeed there is a desire to change the default shell, consideration should be taken to make sure other locations expecting `sh` are updated.

## Related Issues

> Reverts #755 
> Fixes #788 
> Doesn't fix #744 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the user account shell from `/bin/zsh` to `/bin/sh` during user creation for enhanced compatibility.

- **Bug Fixes**
	- Improved handling of SSH configurations, ensuring better security practices and logging for user accounts.

- **Chores**
	- Maintained existing functionalities for SSH key setup, port configuration, and user-defined settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->