### PR TITLE
Update profile filename for zsh

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -107,7 +107,7 @@ if [[ "${username}" != "root" ]]; then
         || bashio::exit.nok 'Failed adding user to wheel group'
 
     # Ensure new user switches to root after login
-    echo 'exec sudo -i' > "/home/${username}/.profile" \
+    echo 'exec sudo -i' > "/home/${username}/.zprofile" \
         || bashio::exit.nok 'Failed configuring user profile'
 fi
 


### PR DESCRIPTION
# Proposed Changes

An earlier PR changed the user shell to zsh. zsh does not run .profile, it looks for .zprofile instead. Changed .profile to .zprofile so that zsh runs it on login.

## Related Issues

#788 
#755 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user session initiation for non-root users by updating profile configuration for Z shell compatibility.
  
- **Bug Fixes**
	- Maintained existing logic for SSH configurations, ensuring consistent behavior in user account setup and security measures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->