### PR TITLE
🔨 Add if statement for bash profile

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -106,9 +106,14 @@ if [[ "${username}" != "root" ]]; then
     adduser "${username}" wheel \
         || bashio::exit.nok 'Failed adding user to wheel group'
 
+    if bashio::config.true 'zsh'; then
     # Ensure new user switches to root after login
-    echo 'exec sudo -i' > "/home/${username}/.zprofile" \
-        || bashio::exit.nok 'Failed configuring user profile'
+        echo 'exec sudo -i' > "/home/${username}/.zprofile" \
+            || bashio::exit.nok 'Failed configuring user profile'
+    else
+        echo 'exec sudo -i' > "/home/${username}/.profile" \
+            || bashio::exit.nok 'Failed configuring user profile'
+    fi
 fi
 
 # We need to set a password for the user account


### PR DESCRIPTION
# Proposed Changes

🔨 Add if statement for bash profile

I'm sure this could be done more elegantly, but adds an if to load the relevant profile based on the addon option.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced shell configuration support for different user environments
  - Added conditional profile setup for `zsh` and default shell configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->