### PR TITLE
Limit shell change to just root

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -52,7 +52,7 @@ fi
 
 # Set up Bash
 if ! bashio::config.true "zsh"; then
-    sed -i -r -e 's|^(root:.*)/bin/zsh$|\1/bin/bash|' /etc/passwd*  
+    sed -i -r -e 's|^(root:.*)/bin/zsh$|\1/bin/bash|' /etc/passwd*
     sed -i -e 's|/zsh$|/bash|' /root/.tmux.conf
 fi
 

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -52,7 +52,7 @@ fi
 
 # Set up Bash
 if ! bashio::config.true "zsh"; then
-    sed -i -e 's|/zsh$|/bash|' /etc/passwd*
+    sed -i -r -e 's|^(root:.*)/bin/zsh$|\1/bin/bash|' /etc/passwd*  
     sed -i -e 's|/zsh$|/bash|' /root/.tmux.conf
 fi
 


### PR DESCRIPTION
# Proposed Changes

When choosing to use bash the root user's shell needs to be changed from zsh (the default) to bash.  Prior to this change all zsh shells for all users were changed, but the non-root user's profile filename becomes inconsistent.  This change ensures that only root's shell is changed.

(The shell/profile combination for the optional non-root user needs to be consistent - either sh/.profile, or zsh/.zprofile.  The non-root user's shell only lasts until the exec in the profile, so it doesn't matter what that shell is.)

(#821 turned out to be incomplete)

## Related Issues

#788
#755
#821


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved shell update mechanism for more precise user environment configuration
	- Enhanced script reliability when modifying user shell settings
<!-- end of auto-generated comment: release notes by coderabbit.ai -->