### PR TITLE
Add support for dotfiles repo

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -94,6 +94,7 @@ packages:
   - build-base
 init_commands:
   - ls -la
+dotfiles_repo: "https://github.com/yourusername/dotfiles"
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -227,6 +228,12 @@ time for the add-on._
 Customize your shell environment even more with the `init_commands` option.
 Add one or more shell commands to the list, and they will be executed every
 single time this add-on starts.
+
+#### Option: `dotfiles_repo`
+
+Specify the URL of your GitHub repository containing your dotfiles. The repository will be cloned, and the setup scripts will be executed to configure your environment.
+
+**Note**: _Ensure the repository URL is correct and accessible._
 
 ## Known issues and limitations
 

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -66,6 +66,7 @@ options:
   share_sessions: false
   packages: []
   init_commands: []
+  dotfiles_repo: ""
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   ssh:
@@ -84,3 +85,4 @@ schema:
     - str
   init_commands:
     - str
+  dotfiles_repo: str

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -113,3 +113,14 @@ if bashio::config.has_value 'init_commands'; then
             || bashio::exit.nok "Failed executing init command: ${cmd}"
     done <<< "$(bashio::config 'init_commands')"
 fi
+
+# Clone the specified dotfiles repository and execute setup scripts
+if bashio::config.has_value 'dotfiles_repo'; then
+    dotfiles_repo=$(bashio::config 'dotfiles_repo')
+    git clone "${dotfiles_repo}" /root/dotfiles \
+        || bashio::exit.nok "Failed to clone dotfiles repository: ${dotfiles_repo}"
+    if [ -f /root/dotfiles/install.sh ]; then
+        bash /root/dotfiles/install.sh \
+            || bashio::exit.nok "Failed to execute dotfiles setup script"
+    fi
+fi


### PR DESCRIPTION
Add support for pulling down and executing user-provided dotfiles repository.

* Add a new configuration option `dotfiles_repo` in `ssh/config.yaml` to specify the GitHub repository URL.
* Update the schema in `ssh/config.yaml` to include the new `dotfiles_repo` option.
* Update `ssh/DOCS.md` to include instructions on how to configure the `dotfiles_repo` option and provide an example configuration.
* Update `ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run` to clone the specified repository from the `dotfiles_repo` option and execute the setup scripts.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for cloning and setting up dotfiles from a specified GitHub repository
	- New configuration option `dotfiles_repo` allows users to automate their environment setup

- **Documentation**
	- Updated SSH add-on documentation to explain the new dotfiles repository configuration option

<!-- end of auto-generated comment: release notes by coderabbit.ai -->