### PR TITLE
Remove VSCode remote section

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -247,17 +247,6 @@ based on the following:
 - `MINOR`: Backwards-compatible new features and enhancements.
 - `PATCH`: Backwards-compatible bugfixes and package updates.
 
-## Visual Studio Code Remote - SSH
-
-Setting the following parameters as is shown will allow you to connect to
-your Home Assistant instance using VSCode Remote - SSH:
-
-```yaml
-ssh:
-  allow_remote_port_forwarding: true
-  allow_tcp_forwarding: true
-```
-
 ## Support
 
 Got questions?


### PR DESCRIPTION
# Proposed Changes

Remove the section on supporting VSCode remote, not sure Alpine will ever be fully supported, so suggest it is removed from the docs (plus the fact that there are better ways for text editing....)


fixes #885 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed the section on "Visual Studio Code Remote - SSH" setup and configuration from the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->