### PR TITLE
Fix /var/log/btmp logging and sudo config perms

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -139,7 +139,8 @@ COPY rootfs /
 RUN \
     chmod 0750 /etc/sudo.conf \
     && chmod 0750 -R /etc/sudoers.d \
-    && chmod 0640 /etc/sudoers.d
+    && chmod 0640 /etc/sudoers.d \
+    && chmod 0660 /var/log/btmp
 
 # Build arguments
 ARG BUILD_ARCH

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -137,9 +137,9 @@ COPY rootfs /
 
 # Ensure right permissions
 RUN \
-    chmod 0750 /etc/sudo.conf \
-    && chmod 0750 -R /etc/sudoers.d \
-    && chmod 0640 /etc/sudoers.d \
+    chmod 0640 /etc/sudo.conf \
+    && chmod 0750 /etc/sudoers.d \
+    && chmod 0640 /etc/sudoers.d/* \
     && chmod 0660 /var/log/btmp
 
 # Build arguments


### PR DESCRIPTION

# Proposed Changes

With incorrect permissions, nothing gets actually logged in btmp by sshd on failed logins, and an error is logged instead:

> Excess permission or bad ownership on file /var/log/btmp

Fix by removing all executable bits and all world access.

Ref https://github.com/openssh/openssh-portable/blob/3e11478f585408888defa56fa47e8dc6567378d0/loginrec.c#L1733-L1737


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated system file permissions to enhance security and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->