### PR TITLE
Fix ssh-audit hardenings

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -144,7 +144,7 @@ RUN \
 # Hardenings, https://www.sshaudit.com/hardening_guides.html
 RUN \
     awk '$5 >= 3071' /etc/ssh/moduli >/etc/ssh/moduli.safe \
-    && mv /etc/ssh/moduli.safe /etc/ssh/moduli
+    && [ -s /etc/ssh/moduli.safe ] && mv /etc/ssh/moduli.safe /etc/ssh/moduli || echo "Warning: /etc/ssh/moduli.safe is empty. SSH moduli file not replaced."
 
 # Build arguments
 ARG BUILD_ARCH

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -141,6 +141,11 @@ RUN \
     && chmod 0750 -R /etc/sudoers.d \
     && chmod 0640 /etc/sudoers.d
 
+# Hardenings, https://www.sshaudit.com/hardening_guides.html
+RUN \
+    awk '$5 >= 3071' /etc/ssh/moduli >/etc/ssh/moduli.safe \
+    && mv /etc/ssh/moduli.safe /etc/ssh/moduli
+
 # Build arguments
 ARG BUILD_ARCH
 ARG BUILD_DATE

--- a/ssh/rootfs/etc/ssh/sshd_config
+++ b/ssh/rootfs/etc/ssh/sshd_config
@@ -23,7 +23,7 @@ HostKey /data/ssh_host_ed25519_key
 # ===================
 Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 MACs -hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128@openssh.com,umac-64-etm@openssh.com,umac-64@openssh.com
-KexAlgorithms -ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group14-sha256
+KexAlgorithms -curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521
 
 # Authentication
 # ===================


### PR DESCRIPTION

# Proposed Changes

Brings current ssh-audit output green again, and adds an additional moduli hardening per their recommendations.

```
# algorithm recommendations (for OpenSSH 9.9)
(rec) !diffie-hellman-group-exchange-sha256 -- kex algorithm to change (increase modulus size to 3072 bits or larger) 
(rec) -curve25519-sha256                    -- kex algorithm to remove 
(rec) -curve25519-sha256@libssh.org         -- kex algorithm to remove 
(rec) -diffie-hellman-group16-sha512        -- kex algorithm to remove 
(rec) -diffie-hellman-group18-sha512        -- kex algorithm to remove 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Security Improvements**
  - Enhanced SSH configuration by restricting the moduli file to use stronger cryptographic parameters.
  - Broadened the list of disallowed SSH key exchange algorithms to improve security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->