### PR TITLE
Add ripgrep to installed packages

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -63,6 +63,7 @@ RUN \
         pulseaudio-utils=17.0-r5 \
         py3-pip=25.1.1-r0 \
         python3=3.12.11-r0 \
+        ripgrep=14.1.1-r0 \
         rsync=3.4.1-r0 \
         sqlite=3.49.2-r1 \
         sudo=1.9.17_p1-r0 \


### PR DESCRIPTION
# Proposed Changes
Hi,
ripgrep is much faster than BusyBox's grep and can be very helpful while checking various log files.

I ran the following on a few MiBs of Zigbee2MQTT logs:
```
$ du -shx .
16M     .
$ find . -type f | wc -l
70
$ hyperfine "rg -uuu linkquality" "busybox grep -r linkquality ."
Benchmark 1: rg -uuu linkquality
  Time (mean ± σ):       6.3 ms ±   0.3 ms    [User: 8.0 ms, System: 10.8 ms]
  Range (min … max):     5.8 ms …   8.5 ms    406 runs
 
Benchmark 2: busybox grep -r linkquality .
  Time (mean ± σ):      86.0 ms ±   2.0 ms    [User: 81.3 ms, System: 4.7 ms]
  Range (min … max):    83.5 ms …  92.3 ms    34 runs
 
Summary
  rg -uuu linkquality ran
   13.68 ± 0.66 times faster than busybox grep -r linkquality .
```

