### PR TITLE
Exclude .vscode-server from backups

### DIFF
--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -51,7 +51,7 @@ map:
   - share:rw
   - ssl:rw
 backup_exclude:
-  - '*/.vscode-server/**'
+  - "*/.vscode-server/**"
 journald: true
 options:
   ssh:


### PR DESCRIPTION
# Proposed Changes

Add backup exclusion for `.vscode-server` directory to save 100-200 MB in backup size.

vscode server is automatically redownloaded on next connection if unavailable, so no need to back it up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backup exclusion configuration to automatically exclude VSCode server directories from system backups. This optimization reduces backup size and improves backup performance, ensuring storage resources are allocated efficiently for critical system data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->