### PR TITLE
Drop support for armv7 systems

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -149,8 +146,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-ssh.svg
 [commits]: https://github.com/hassio-addons/addon-ssh/commits/main
 [contributors]: https://github.com/hassio-addons/addon-ssh/graphs/contributors
@@ -166,7 +161,6 @@ SOFTWARE.
 [github-actions-shield]: https://github.com/hassio-addons/addon-ssh/workflows/CI/badge.svg
 [github-actions]: https://github.com/hassio-addons/addon-ssh/actions
 [hass-ssh]: https://github.com/home-assistant/addons/tree/master/ssh
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-ssh/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-ssh.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/ssh/build.yaml
+++ b/ssh/build.yaml
@@ -2,4 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.1
   amd64: ghcr.io/hassio-addons/base:18.2.1
-  armv7: ghcr.io/hassio-addons/base:18.2.1

--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -15,7 +15,6 @@ homeassistant: 0.92.0b2
 arch:
   - aarch64
   - amd64
-  - armv7
 ports:
   22/tcp: 22
 ports_description:


### PR DESCRIPTION
# Proposed Changes

Home Assistant has deprecated support for armv7 systems, and is being dropped completely in Home Assistant 2025.12