### PR TITLE
🐛 Fix unreadable terminal text in Safari/iOS and Firefox

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
@@ -23,6 +23,10 @@ options+=(-i hassio)
 # We want to be able to use the terminal
 options+=(--writable)
 
+# Force explicit terminal colors to ensure readability regardless of
+# browser color-scheme settings (fixes invisible text on Safari/iOS)
+options+=(--theme '{"background":"#1e1e1e","foreground":"#d4d4d4","cursor":"#d4d4d4","cursorAccent":"#1e1e1e","selection":"rgba(255,255,255,0.3)"}')
+
 # Get assigned Ingress port
 ingress_port=$(bashio::addon.ingress_port)
 options+=(-p "${ingress_port}")


### PR DESCRIPTION
Without an explicit terminal color theme, ttyd relies on browser defaults for the xterm.js foreground and background colors. HA 2026.04 changed how color schemes are propagated into ingress iframes, which causes certain browsers (Safari on iOS/macOS, some Firefox configurations) to render the terminal with matching foreground and background colors — making text invisible.

Fixes this by passing an explicit dark theme to ttyd via `--theme`, so the terminal always renders with a consistent, readable color scheme regardless of the browser's color-scheme setting.

Closes #1016.
Closes #1026.