### PR TITLE
Revert "🐛 Fix unreadable terminal text in Safari/iOS and Firefox"

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
@@ -23,10 +23,6 @@ options+=(-i hassio)
 # We want to be able to use the terminal
 options+=(--writable)
 
-# Force explicit terminal colors to ensure readability regardless of
-# browser color-scheme settings (fixes invisible text on Safari/iOS)
-options+=(--theme '{"background":"#1e1e1e","foreground":"#d4d4d4","cursor":"#d4d4d4","cursorAccent":"#1e1e1e","selection":"rgba(255,255,255,0.3)"}')
-
 # Get assigned Ingress port
 ingress_port=$(bashio::addon.ingress_port)
 options+=(-p "${ingress_port}")


### PR DESCRIPTION
Reverts hassio-addons/app-ssh#1033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal color configuration now respects browser color-scheme preferences instead of using hardcoded settings, providing a better visual experience aligned with system and browser theme choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->