### PR TITLE
🐛 Fix terminal rendering issues on iOS Safari via DOM renderer

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
@@ -23,6 +23,11 @@ options+=(-i hassio)
 # We want to be able to use the terminal
 options+=(--writable)
 
+# Use DOM renderer for xterm.js to ensure compatibility with iOS Safari
+# and other browsers where WebGL/Canvas rendering causes display issues
+# Fixes: #1016, #1026, #1027
+options+=(--client-option rendererType=dom)
+
 # Get assigned Ingress port
 ingress_port=$(bashio::addon.ingress_port)
 options+=(-p "${ingress_port}")


### PR DESCRIPTION
## What

Add `--client-option rendererType=dom` to the ttyd options in the run script.

## Why

xterm.js defaults to WebGL → Canvas → DOM renderer order. On iOS Safari, the WebGL and Canvas renderers produce garbled, unreadable terminal output. Pinning to the DOM renderer fixes this.

This is a separate issue from the theme color change in #1033/#1034. That PR addressed unreadable text contrast; this addresses the renderer producing garbled output on iOS.

Closes #1016
Closes #1026
Closes #1027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched the web terminal client to DOM-based rendering. This may change visual appearance, text/emoji rendering, and performance characteristics in the in-browser terminal display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->