### PR TITLE
🐛 Exit cleanly when SSH access is disabled

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -6,7 +6,9 @@ FROM ${BUILD_FROM}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Add env
-ENV TERM="xterm-256color"
+ENV \
+    TERM="xterm-256color" \
+    S6_STAGE2_HOOK=/etc/s6-overlay/scripts/enable-check.sh
 
 # Copy Python requirements file
 COPY requirements.txt /tmp/

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/sshd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/sshd/run
@@ -6,11 +6,6 @@
 # ==============================================================================
 declare -a options
 
-# If SSH is disabled, use a fake sleep process
-if ! bashio::var.has_value "$(bashio::app.port 22)"; then
-    exec sleep 864000
-fi
-
 bashio::log.info 'Starting the SSH daemon...'
 
 # Default options

--- a/ssh/rootfs/etc/s6-overlay/scripts/enable-check.sh
+++ b/ssh/rootfs/etc/s6-overlay/scripts/enable-check.sh
@@ -1,0 +1,13 @@
+#!/command/with-contenv bashio
+# shellcheck shell=bash
+# ==============================================================================
+# Enable optional services based on the add-on configuration
+# ==============================================================================
+
+# Disable the SSH daemon when no SSH port is exposed
+if ! bashio::var.has_value "$(bashio::app.port 22)"; then
+    bashio::log.info \
+        "No network port is defined in the configuration so access" \
+        "will only be available via the web interface."
+    rm -f /etc/s6-overlay/s6-rc.d/user/contents.d/sshd
+fi


### PR DESCRIPTION
# Proposed Changes

When the SSH port is not exposed, the sshd service ran a `sleep 864000` placeholder. On graceful shutdown that placeholder was killed by SIGTERM, causing the finish script to set the container exit code to 143.

Disable the sshd service entirely via an `S6_STAGE2_HOOK` script that removes it from the user bundle when no SSH port is configured, matching the pattern used by some official add-ons. The container now exits with 0 on a graceful shutdown.

## Related Issues

https://github.com/home-assistant/supervisor/issues/6840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH daemon now reliably starts on container initialization.

* **New Features**
  * Added automatic detection to disable SSH daemon when port 22 is not configured in addon settings.

* **Chores**
  * Updated container environment configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hassio-addons/app-ssh/pull/1051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->