### PR TITLE
Load potential user-supplied extra SSHd configuration files from /etc/ssh/sshd_config.d/*.conf

### DIFF
--- a/ssh/rootfs/etc/ssh/ssh_config
+++ b/ssh/rootfs/etc/ssh/ssh_config
@@ -45,6 +45,14 @@
 #   RekeyLimit 1G 1h
 #   UserKnownHostsFile ~/.ssh/known_hosts.d/%k
 
+# User-supplied extras
+# ===================
+# OpenSSH uses unintuitive “first value wins” rules, so any value set in an
+# override file will override the values below only if the Include is *first*.
+Include ssh_config.d/*.conf
+
+# Prefer secure ciphers
+# ===================
 HostKeyAlgorithms -ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com
 KexAlgorithms -diffie-hellman-group14-sha256,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521
 MACs -hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128@openssh.com,umac-64-etm@openssh.com,umac-64@openssh.com

--- a/ssh/rootfs/etc/ssh/sshd_config
+++ b/ssh/rootfs/etc/ssh/sshd_config
@@ -1,3 +1,9 @@
+# User-supplied extras
+# ===================
+# OpenSSH uses unintuitive “first value wins” rules, so any value set in an
+# override file will override the values below only if the Include is *first*.
+Include sshd_config.d/*.conf
+
 # Basics
 # ===================
 Port 22


### PR DESCRIPTION
The directory already existed making this omission rather confusing.

# Proposed Changes

See title, just also loads configuration files from /etc/ssh/sshd_config.d/*.conf on SSHd startup.

Workaround is adding `echo 'Include sshd_config.d/*.conf' >> /etc/ssh/sshd_config` to init_commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * SSH daemon updated to load additional, user-provided configuration snippets and now shows a "User‑supplied extras" section for custom settings.
  * System-wide SSH client configuration similarly updated to load extra snippet files and includes a "User‑supplied extras" section plus guidance on preferred secure ciphers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hassio-addons/app-ssh/pull/1057?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->