### PR TITLE
🔨 Use bashio::app.* instead of deprecated bashio::addon.*

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-docker/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-docker/run
@@ -5,7 +5,7 @@
 # Home Assistant Community App: Advanced SSH & Web Terminal
 # Enables Docker by moving the Docker executable in place.
 # ==============================================================================
-if bashio::var.false "$(bashio::addon.protected)"; then
+if bashio::var.false "$(bashio::app.protected)"; then
     rm /usr/local/bin/docker
     mv /usr/local/bin/.undocked /usr/local/bin/docker
     bashio::log.info 'Docker support has been enabled.'

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -12,7 +12,7 @@ declare password
 declare port
 declare username
 
-port=$(bashio::addon.port 22)
+port=$(bashio::app.port 22)
 
 # Don't execute this when SSH is disabled
 if ! bashio::var.has_value "${port}"; then

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/sshd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/sshd/run
@@ -7,7 +7,7 @@
 declare -a options
 
 # If SSH is disabled, use a fake sleep process
-if ! bashio::var.has_value "$(bashio::addon.port 22)"; then
+if ! bashio::var.has_value "$(bashio::app.port 22)"; then
     exec sleep 864000
 fi
 

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/ttyd/run
@@ -24,7 +24,7 @@ options+=(-i hassio)
 options+=(--writable)
 
 # Get assigned Ingress port
-ingress_port=$(bashio::addon.ingress_port)
+ingress_port=$(bashio::app.ingress_port)
 options+=(-p "${ingress_port}")
 
 ttyd_command=(tmux -u new -A -s homeassistant zsh -l)


### PR DESCRIPTION
# Proposed Changes

As of bashio v0.18.0, the `bashio::addon.*` namespace was renamed to
`bashio::app.*`. The old names still work through deprecated aliases, but each
call now emits a one-time `bashio::addon.X is deprecated, use bashio::app.X
instead.` warning into the add-on log.

This updates the four call sites to the new namespace to silence those
warnings:

- `bashio::addon.port` → `bashio::app.port` (`sshd/run`, `init-ssh/run`)
- `bashio::addon.protected` → `bashio::app.protected` (`init-docker/run`)
- `bashio::addon.ingress_port` → `bashio::app.ingress_port` (`ttyd/run`)

Purely a rename; no behavioral change.

## Related Issues

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
