### PR TITLE
🐛 Fix malformed redirect when setting the account password

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -118,7 +118,8 @@ else
     # Use a random password in case none is set
     password=$(pwgen 64 1)
 fi
-chpasswd <<< "${username}:${password}" 2&> /dev/null
+chpasswd <<< "${username}:${password}" 2> /dev/null \
+    || bashio::exit.nok 'Failed setting the password for the user account'
 
 # Sets up the authorized SSH keys
 if bashio::config.has_value 'ssh.authorized_keys'; then


### PR DESCRIPTION
# Proposed Changes

The `chpasswd` call that sets the account password used a malformed redirect:

```bash
chpasswd <<< "${username}:${password}" 2&> /dev/null
```

`2&>` does not redirect stderr. Bash parses it as a literal `2` argument passed to `chpasswd`, followed by `&>` which redirects both stdout and stderr to `/dev/null`. As a result a stray `2` was handed to `chpasswd`, and, more importantly, every error was swallowed with no exit-status check. If `chpasswd` failed (for example on a rejected password), it failed silently, leaving the user with a broken login and nothing in the log to explain it.

This drops the stray argument, redirects only stderr, and surfaces a failure through `bashio::exit.nok` so the problem is logged instead of hidden.

## Related Issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH initialization error handling to increase reliability of the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->