### PR TITLE
🔒 Restrict permissions on generated service credential files

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-mosquitto/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-mosquitto/run
@@ -23,6 +23,10 @@ if bashio::services.available "mqtt"; then
     echo "--username ${username}"
   } > /root/.config/mosquitto_sub
 
+  # Credentials are stored in plain text, keep them owner-only readable
+  chmod 600 /root/.config/mosquitto_sub \
+    || bashio::exit.nok 'Failed securing the Mosquitto client configuration'
+
   ln -s /root/.config/mosquitto_sub /root/.config/mosquitto_pub
   ln -s /root/.config/mosquitto_sub /root/.config/mosquitto_rr
 fi

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-mysql/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-mysql/run
@@ -23,4 +23,8 @@ if bashio::services.available "mysql"; then
     echo "port=${port}"
     echo "user=\"${username}\""
   } > /etc/my.cnf.d/service.cnf
+
+  # Credentials are stored in plain text, keep them owner-only readable
+  chmod 600 /etc/my.cnf.d/service.cnf \
+    || bashio::exit.nok 'Failed securing the MySQL client configuration'
 fi


### PR DESCRIPTION
# Proposed Changes

When a MySQL or MQTT service is available, the add-on writes the service credentials to client configuration files:

- `/etc/my.cnf.d/service.cnf` (MySQL, contains the password)
- `/root/.config/mosquitto_sub` (Mosquitto, contains the password, also symlinked to `mosquitto_pub` and `mosquitto_rr`)

These files were created with the default umask, so the plaintext passwords were more readable than they need to be. This sets both files to `0600` right after they are written, so the credentials are only readable by their owner. The Mosquitto symlinks point at the same file, so they inherit the tightened permissions.

It is a single-user container, so this is defense in depth rather than a fix for an exploitable issue.
