### PR TITLE
🔒 Exclude the SSH environment file from backups

### DIFF
--- a/ssh/config.yaml
+++ b/ssh/config.yaml
@@ -51,6 +51,7 @@ map:
   - ssl:rw
 backup_exclude:
   - "*/.vscode-server/**"
+  - "*/.ssh/environment"
 journald: true
 options:
   ssh:


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`init-user` writes the Supervisor API token to `/data/.ssh/environment` on every start, so that `sshd` can expose it to sessions through `PermitUserEnvironment`. Since it lives under `/data`, that file is also captured in add-on backups.

The token is rewritten fresh on each start and rotates, so a copy captured in a backup is of little practical use, but there is no reason to carry a secret into backup archives at all. This adds `*/.ssh/environment` to `backup_exclude` so it is left out, matching the existing pattern used for the VS Code server directory.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
