### PR TITLE
🔨 Tidy compatibility-mode sshd_config regexes

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -155,9 +155,9 @@ fi
 
 # This enabled less strict ciphers, macs, and keyx.
 if bashio::config.true 'ssh.compatibility_mode'; then
-    sed -i '/Ciphers\ .*/s/^/#/g' "${SSH_CONFIG_PATH}"
-    sed -i '/MACs\ .*/s/^/#/g' "${SSH_CONFIG_PATH}"
-    sed -i '/KexAlgorithms\.* /s/^/#/g' "${SSH_CONFIG_PATH}"
+    sed -i '/^Ciphers /s/^/#/' "${SSH_CONFIG_PATH}"
+    sed -i '/^MACs /s/^/#/' "${SSH_CONFIG_PATH}"
+    sed -i '/^KexAlgorithms /s/^/#/' "${SSH_CONFIG_PATH}"
     bashio::log.notice 'SSH is running in compatibility mode!'
     bashio::log.warning 'Compatibility mode is less secure!'
     bashio::log.warning 'Please only enable it when you know what you are doing!'


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

When compatibility mode is enabled, the add-on comments out the hardened `Ciphers`, `MACs` and `KexAlgorithms` lines in `sshd_config` so OpenSSH falls back to its defaults. The three `sed` expressions doing this were inconsistent, and the `KexAlgorithms` one relied on an accidental pattern (`/KexAlgorithms\.* /`, a literal dot repeated zero or more times) that only matched by luck.

This rewrites all three to the same clear, anchored form:

```bash
sed -i '/^Ciphers /s/^/#/' "${SSH_CONFIG_PATH}"
sed -i '/^MACs /s/^/#/' "${SSH_CONFIG_PATH}"
sed -i '/^KexAlgorithms /s/^/#/' "${SSH_CONFIG_PATH}"
```

The redundant `g` flag (only one line start per line) is dropped as well. Behavior is unchanged: verified against the shipped `sshd_config` that exactly those three directive lines get commented and nothing else.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
