### PR TITLE
🐛 Keep starting when custom package installation fails

### DIFF
--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-user/run
@@ -96,14 +96,22 @@ if ! bashio::config.true 'share_sessions'; then
 fi
 
 # Install user configured/requested packages
+#
+# Failures here are intentionally non-fatal: if the package indexes or a
+# package cannot be fetched (e.g. broken DNS or no network), we still want
+# the terminal to come up so the host remains reachable for debugging.
 if bashio::config.has_value 'packages'; then
-    apk update \
-        || bashio::exit.nok 'Failed updating Alpine packages repository indexes'
-
-    for package in $(bashio::config 'packages'); do
-        apk add "$package" \
-            || bashio::exit.nok "Failed installing package ${package}"
-    done
+    if apk update; then
+        for package in $(bashio::config 'packages'); do
+            apk add "$package" \
+                || bashio::log.warning "Failed installing package ${package}"
+        done
+    else
+        bashio::log.warning \
+            'Failed updating the Alpine package indexes, is the network up?'
+        bashio::log.warning \
+            'Skipping installation of custom packages so access stays available.'
+    fi
 fi
 
 # Executes user configured/requested commands on startup


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

When custom `packages` are configured and the package indexes or a package cannot be fetched (for example a broken DNS or no network), `init-user` ran `apk update || bashio::exit.nok`, which aborted the whole startup and took the container down. That is the worst possible moment to lose the terminal: it removes SSH access to the host exactly when you need it to debug the network problem.

This makes the custom package installation non-fatal:

- If `apk update` fails, it logs a warning, skips installing the custom packages, and continues startup so the terminal stays reachable.
- If an individual `apk add` fails, it logs a warning for that package and continues with the rest instead of aborting.

Behavior is unchanged on the happy path. This matches the suggestion in the issue: continue startup without the custom packages and surface a warning.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Closes #1001

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system startup resilience. Package installation failures no longer halt startup. The system now logs warnings and continues operation if package repository updates or individual package installations encounter errors, improving recovery from transient issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->