### PR TITLE
📝 Document clipboard copy and paste in the Web Terminal

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -225,6 +225,20 @@ Customize your shell environment even more with the `init_commands` option.
 Add one or more shell commands to the list, and they will be executed every
 single time this app starts.
 
+## Clipboard: copying and pasting
+
+The Web Terminal is based on xterm.js, which follows X11-style clipboard
+conventions that may differ from what you expect:
+
+- **Copy**: hold `Shift` and select the text with your mouse. The selection is
+  copied to your system clipboard right away (a small scissors icon briefly
+  pops up). There is no need to press `Ctrl+C`.
+- **Paste**: press `Ctrl+Shift+V`, or right-click and choose paste, depending
+  on your browser.
+
+This applies to the Web Terminal in the Home Assistant frontend. A regular SSH
+client uses the clipboard behavior of its own terminal instead.
+
 ## Known issues and limitations
 
 - When SFTP is enabled, the username MUST be set to `root`.


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The Web Terminal is based on xterm.js, which uses X11-style clipboard conventions: you copy by holding `Shift` while selecting text (no `Ctrl+C`), and paste with `Ctrl+Shift+V`. This is not obvious and was previously only findable in a buried 2019 community forum thread, so many users never discover how to copy and paste at all.

This adds a short "Clipboard: copying and pasting" section to the add-on documentation explaining both, and clarifies that it applies to the Web Terminal specifically (a regular SSH client uses its own terminal's clipboard behavior).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Closes #1048

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
