### PR TITLE
📝 Document running ha and the Supervisor API non-interactively

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -231,6 +231,31 @@ single time this app starts.
 - If you want to use rsync for file transfer, the username MUST be set to
   `root`.
 
+## Running the `ha` command or Supervisor API non-interactively
+
+When you log in interactively, the app starts a login shell that sets up the
+`SUPERVISOR_TOKEN` environment variable. The `ha` command and the Supervisor
+API need that token, so commands like `ha core info` just work.
+
+Running a command non-interactively does **not** start a login shell, so the
+token is not set and the command fails with a `401` error. For example, this
+fails:
+
+```shell
+ssh your-instance "ha core info"
+```
+
+Wrap the command in a login shell so the environment, and with it the token,
+is loaded:
+
+```shell
+ssh your-instance 'bash -lc "ha core info"'
+```
+
+The same applies when calling the Supervisor API directly or running commands
+from automations: invoke them through a login shell (`bash -lc '...'`) so the
+`SUPERVISOR_TOKEN` is available.
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Several discussions report that `ha` commands and Supervisor API calls fail over SSH when run non-interactively, for example `ssh your-instance "ha core info"` returning a `401`, while the exact same command works once logged in interactively.

The cause is the shell: an interactive login starts a login shell, which loads `/etc/profile.d` and exports `SUPERVISOR_TOKEN` (which `ha` and the Supervisor API need). A non-interactive `ssh host "cmd"` runs a non-login shell, which does not load `/etc/profile.d`, so the token is missing and the request is rejected with `401`. Verified in the base image: `bash -c` does not pick up the token, `bash -lc` does.

This adds a documentation section explaining the behavior and the reliable workaround: wrap the command in a login shell, e.g. `ssh your-instance 'bash -lc "ha core info"'`. This works regardless of the configured username and needs no changes to the add-on.

I deliberately kept this to documentation. Making the bare `ssh host "cmd"` form work would mean injecting the token into non-login shells (per-user `~/.ssh/environment` or `BASH_ENV`), which changes the add-on's deliberate session model and warrants live testing first. Happy to explore that as a follow-up if wanted.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Refs #373, #732, #417, #393

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
