### PR TITLE
✨ Replace Vim with Neovim, mapping vi/vim/neovim to nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ well. Additionally, it comes out of the box with the following:
   ["Oh My ZSH"][ohmyzsh], with some plugins enabled as well.
 - Contains a sensible set of tools right out of the box: curl, Wget, RSync, GIT,
   Nmap, Mosquitto client, MariaDB/MySQL client, Awake ("wake on LAN"), Nano,
-  Vim, tmux, and a bunch commonly used networking tools.
+  Neovim, tmux, and a bunch commonly used networking tools.
 
 ## Support
 

--- a/ssh/.README.j2
+++ b/ssh/.README.j2
@@ -62,7 +62,7 @@ well. Additionally, it comes out of the box with the following:
   ["Oh My ZSH"][ohmyzsh], with some plugins enabled as well.
 - Contains a sensible set of tools right out of the box: curl, Wget, RSync, GIT,
   Nmap, Mosquitto client, MariaDB/MySQL client, Awake ("wake on LAN"), Nano,
-  Vim, tmux, and a bunch commonly used networking tools.
+  Neovim, tmux, and a bunch commonly used networking tools.
 
 {% if channel == "edge" %}
 ## WARNING! THIS IS AN EDGE VERSION!

--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -49,7 +49,7 @@ well. Additionally, it comes out of the box with the following:
   ["Oh My ZSH"][ohmyzsh], with some plugins enabled as well.
 - Contains a sensible set of tools right out of the box: curl, Wget, RSync, GIT,
   Nmap, Mosquitto client, MariaDB/MySQL client, Awake ("wake on LAN"), Nano,
-  Vim, tmux, and a bunch commonly used networking tools.
+  Neovim, tmux, and a bunch commonly used networking tools.
 
 ## Installation
 

--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -56,6 +56,7 @@ RUN \
         nano-syntax=9.0-r0 \
         nano=9.0-r0 \
         ncurses=6.6_p20260516-r0 \
+        neovim=0.12.2-r0 \
         net-tools=2.10-r3 \
         nmap=7.99-r0 \
         openssh=10.3_p1-r0 \
@@ -70,7 +71,6 @@ RUN \
         sudo=1.9.17_p2-r1 \
         tmux=3.6b-r0 \
         ttyd=1.7.7-r0 \
-        vim=9.2.0602-r0 \
         wget=1.25.0-r3 \
         zip=3.0-r13 \
         zsh-autosuggestions=0.7.1-r0 \
@@ -89,6 +89,10 @@ RUN \
     && sed -i -e "s#bin/sh#bin/zsh#" /etc/passwd \
     \
     && cp /usr/bin/docker /usr/local/bin/.undocked \
+    \
+    && ln -s -f /usr/bin/nvim /usr/bin/vim \
+    && ln -s -f /usr/bin/nvim /usr/bin/vi \
+    && ln -s -f /usr/bin/nvim /usr/bin/neovim \
     \
     && pip3 install -r /tmp/requirements.txt \
     \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Replaces Vim with Neovim, while keeping every familiar command working. The `vim` package is removed and `neovim` is installed, then `vim`, `vi`, and `neovim` are symlinked to `nvim`, so all four commands launch Neovim:

- `nvim` -> Neovim (the package binary)
- `vim` -> `/usr/bin/nvim`
- `vi` -> `/usr/bin/nvim` (previously the BusyBox `vi` applet)
- `neovim` -> `/usr/bin/nvim`

The Features list in the README, docs, and repository template now mentions Neovim instead of Vim.

Verified in a built image: all four commands resolve to `/usr/bin/nvim` and report `NVIM v0.12.2`, the old `vim` package is no longer installed, and a headless open/edit/write/quit round-trip works.

**Note:** removing the `vim` package also drops its `ex`, `view`, `rview`, and `rvim` helpers. The requested `vi`/`vim`/`neovim`/`nvim` are all covered; let me know if you also want `view` mapped to `nvim -R`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
