### PR TITLE
✨ Add disk and storage tools (ncdu, lsblk, smartmontools)

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -50,11 +50,13 @@ RUN \
         libstdc++=15.2.0-r5 \
         libuv=1.52.1-r0 \
         libxml2-utils=2.13.9-r2 \
+        lsblk=2.42-r0 \
         mariadb-client=11.8.8-r0 \
         mosh=1.4.0-r18 \
         mosquitto-clients=2.1.2-r1 \
         nano-syntax=9.0-r0 \
         nano=9.0-r0 \
+        ncdu=1.22-r2 \
         ncurses=6.6_p20260516-r0 \
         neovim=0.12.2-r0 \
         net-tools=2.10-r3 \
@@ -67,6 +69,7 @@ RUN \
         py3-pip=26.1.2-r0 \
         python3=3.14.5-r0 \
         rsync=3.4.3-r1 \
+        smartmontools=7.5-r0 \
         sqlite=3.53.2-r0 \
         sudo=1.9.17_p2-r1 \
         tmux=3.6b-r0 \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Ships a few commonly requested disk and storage tools by default, based on recurring questions on the Home Assistant community forums:

- **ncdu** (`ncdu`): interactive disk usage explorer, handy on space-constrained instances.
- **lsblk** (`lsblk`): list block devices and partitions.
- **smartctl** (`smartmontools`): read disk and SSD S.M.A.R.T. health, a recurring forum request.

These fit the add-on's debugging purpose and add roughly 1.8 MB combined. Verified in a built image that `ncdu`, `lsblk`, and `smartctl` are present.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
