### PR TITLE
✨ Add Midnight Commander (mc)

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -51,6 +51,7 @@ RUN \
         libuv=1.52.1-r0 \
         libxml2-utils=2.13.9-r2 \
         mariadb-client=11.8.8-r0 \
+        mc=4.8.33-r3 \
         mosh=1.4.0-r18 \
         mosquitto-clients=2.1.2-r1 \
         nano-syntax=9.0-r0 \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Ships **Midnight Commander** (`mc`) by default. It is one of the most requested additions for this add-on: the community forum has a dedicated, 1000+ post thread about installing it.

Midnight Commander is a full-screen text-mode file manager that many users prefer for navigating and editing files over SSH. It adds roughly 2.4 MB. Verified in a built image that `mc` is present and reports `GNU Midnight Commander 4.8.33`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
