### PR TITLE
✨ Add GNU Screen

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -71,6 +71,7 @@ RUN \
         py3-pip=26.1.2-r0 \
         python3=3.14.5-r0 \
         rsync=3.4.3-r1 \
+        screen=5.0.1-r1 \
         smartmontools=7.5-r0 \
         sqlite=3.53.2-r0 \
         sudo=1.9.17_p2-r1 \


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Ships **GNU Screen** (`screen`) by default. There is a dedicated community forum thread asking how to use Screen with this add-on, and many users reach for it out of habit for detaching and reattaching terminal sessions.

The add-on already ships tmux with session sharing, which covers much of the same ground, so this is mostly about meeting users' muscle memory. It adds roughly 0.6 MB. Verified in a built image that `screen` is present and reports `Screen version 5.0.1`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated the deployment environment configuration to include an additional package in the Docker build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->