### PR TITLE
📝 Add an example to the packages option documentation

### DIFF
--- a/ssh/DOCS.md
+++ b/ssh/DOCS.md
@@ -216,6 +216,22 @@ effectively sets SSH to behave as it used to be.
 Allows you to specify additional [Alpine packages][alpine-packages] to be
 installed in your shell environment (e.g., Python, Joe, Irssi).
 
+The packages are installed using Alpine's package manager, so any package name
+from the [Alpine package index][alpine-packages] works. List the package names
+exactly as they appear there. For example:
+
+```yaml
+packages:
+  - iperf3
+  - socat
+  - joe
+```
+
+This installs the packages on every start, so they are always available when
+you log in. Note that package names are not always the same as the command
+they provide (for example, the `ncat` command comes from the `nmap-ncat`
+package).
+
 **Note**: _Adding many packages will result in a longer start-up
 time for the app._
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The `packages` option lets users install any Alpine package on start, but the docs only described it in one line. The community forums have a steady stream of "how do I install X" and "command not found" threads, so this expands the option's documentation with a concrete YAML example and two clarifications:

- Package names must match the Alpine package index exactly.
- The package name is not always the command name (for example, the `ncat` command comes from the `nmap-ncat` package).

The example uses packages that are not shipped by default (`iperf3`, `socat`, `joe`) so it does not contradict the built-in tool set.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
