### PR TITLE
Load potential user-supplied extra SSH(d) configuration files from /config/ssh{d,}_config.d/*.conf

### DIFF
--- a/ssh/Dockerfile
+++ b/ssh/Dockerfile
@@ -126,6 +126,11 @@ RUN \
     && chmod 0640 /etc/sudoers.d/* \
     && chmod 0660 /var/log/btmp
 
+# Remove SSH drop-in directories inherited from Alpine to avoid confusion
+# with the drop-in directories managed by /etc/s6-overlay/s6-rc.d/init-ssh/run
+RUN \
+    rmdir /etc/ssh/ssh_config.d /etc/ssh/sshd_config.d
+
 # Hardenings, https://www.sshaudit.com/hardening_guides.html
 RUN \
     awk '$5 >= 3071' /etc/ssh/moduli >/etc/ssh/moduli.safe \

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -4,8 +4,8 @@
 # Home Assistant Community App: Advanced SSH & Web Terminal
 # Configures the SSH daemon
 # ==============================================================================
-readonly SSH_AUTHORIZED_KEYS_PATH=/etc/ssh/authorized_keys
-readonly SSH_CONFIG_PATH=/etc/ssh/sshd_config
+readonly SSH_HOST_AUTHORIZED_KEYS_PATH=/etc/ssh/authorized_keys
+readonly SSH_HOST_CONFIG_PATH=/etc/ssh/sshd_config
 readonly SSH_HOST_ED25519_KEY=/data/ssh_host_ed25519_key
 readonly SSH_HOST_RSA_KEY=/data/ssh_host_rsa_key
 declare password
@@ -124,41 +124,41 @@ chpasswd <<< "${username}:${password}" 2> /dev/null \
 # Sets up the authorized SSH keys
 if bashio::config.has_value 'ssh.authorized_keys'; then
     while read -r key; do
-        echo "${key}" >> "${SSH_AUTHORIZED_KEYS_PATH}"
+        echo "${key}" >> "${SSH_HOST_AUTHORIZED_KEYS_PATH}"
     done <<< "$(bashio::config 'ssh.authorized_keys')"
 fi
 
 # Port
-sed -i "s/Port\\ .*/Port\\ ${port}/" "${SSH_CONFIG_PATH}" \
+sed -i "s/Port\\ .*/Port\\ ${port}/" "${SSH_HOST_CONFIG_PATH}" \
     || bashio::exit.nok 'Failed configuring port'
 
 # SFTP access
 if bashio::config.true 'ssh.sftp'; then
-    sed -i '/Subsystem sftp/s/^#//g' "${SSH_CONFIG_PATH}"
+    sed -i '/Subsystem sftp/s/^#//g' "${SSH_HOST_CONFIG_PATH}"
     bashio::log.notice 'SFTP access is enabled'
 fi
 
 # Allow specified user to log in
 if [[ "${username}" != "root" ]]; then
-    sed -i "s/AllowUsers\\ .*/AllowUsers\\ ${username}/" "${SSH_CONFIG_PATH}" \
+    sed -i "s/AllowUsers\\ .*/AllowUsers\\ ${username}/" "${SSH_HOST_CONFIG_PATH}" \
         || bashio::exit.nok 'Failed opening SSH for the configured user'
 else
-    sed -i "s/PermitRootLogin\\ .*/PermitRootLogin\\ yes/" "${SSH_CONFIG_PATH}" \
+    sed -i "s/PermitRootLogin\\ .*/PermitRootLogin\\ yes/" "${SSH_HOST_CONFIG_PATH}" \
         || bashio::exit.nok 'Failed opening SSH for the root user'
 fi
 
 # Enable password authentication when password is set
 if bashio::config.has_value 'ssh.password'; then
     sed -i "s/PasswordAuthentication.*/PasswordAuthentication\\ yes/" \
-        "${SSH_CONFIG_PATH}" \
+        "${SSH_HOST_CONFIG_PATH}" \
           || bashio::exit.nok 'Failed to setup SSH password authentication'
 fi
 
 # This enabled less strict ciphers, macs, and keyx.
 if bashio::config.true 'ssh.compatibility_mode'; then
-    sed -i '/^Ciphers /s/^/#/' "${SSH_CONFIG_PATH}"
-    sed -i '/^MACs /s/^/#/' "${SSH_CONFIG_PATH}"
-    sed -i '/^KexAlgorithms /s/^/#/' "${SSH_CONFIG_PATH}"
+    sed -i '/^Ciphers /s/^/#/' "${SSH_HOST_CONFIG_PATH}"
+    sed -i '/^MACs /s/^/#/' "${SSH_HOST_CONFIG_PATH}"
+    sed -i '/^KexAlgorithms /s/^/#/' "${SSH_HOST_CONFIG_PATH}"
     bashio::log.notice 'SSH is running in compatibility mode!'
     bashio::log.warning 'Compatibility mode is less secure!'
     bashio::log.warning 'Please only enable it when you know what you are doing!'
@@ -167,20 +167,20 @@ fi
 # Enable Agent forwarding
 if bashio::config.true 'ssh.allow_agent_forwarding'; then
     sed -i "s/AllowAgentForwarding.*/AllowAgentForwarding\\ yes/" \
-        "${SSH_CONFIG_PATH}" \
+        "${SSH_HOST_CONFIG_PATH}" \
           || bashio::exit.nok 'Failed to setup SSH Agent Forwarding'
 fi
 
 # Allow remote port forwarding
 if bashio::config.true 'ssh.allow_remote_port_forwarding'; then
     sed -i "s/GatewayPorts.*/GatewayPorts\\ yes/" \
-        "${SSH_CONFIG_PATH}" \
+        "${SSH_HOST_CONFIG_PATH}" \
           || bashio::exit.nok 'Failed to setup remote port forwarding'
 fi
 
 # Allow TCP forewarding
 if bashio::config.true 'ssh.allow_tcp_forwarding'; then
     sed -i "s/AllowTcpForwarding.*/AllowTcpForwarding\\ yes/" \
-        "${SSH_CONFIG_PATH}" \
+        "${SSH_HOST_CONFIG_PATH}" \
           || bashio::exit.nok 'Failed to setup SSH TCP Forwarding'
 fi

--- a/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
+++ b/ssh/rootfs/etc/s6-overlay/s6-rc.d/init-ssh/run
@@ -4,6 +4,8 @@
 # Home Assistant Community App: Advanced SSH & Web Terminal
 # Configures the SSH daemon
 # ==============================================================================
+readonly SSH_CLIENT_DROPIN_DIR=/config/ssh_config.d
+readonly SSH_HOST_DROPIN_DIR=/config/sshd_config.d
 readonly SSH_HOST_AUTHORIZED_KEYS_PATH=/etc/ssh/authorized_keys
 readonly SSH_HOST_CONFIG_PATH=/etc/ssh/sshd_config
 readonly SSH_HOST_ED25519_KEY=/data/ssh_host_ed25519_key
@@ -127,6 +129,9 @@ if bashio::config.has_value 'ssh.authorized_keys'; then
         echo "${key}" >> "${SSH_HOST_AUTHORIZED_KEYS_PATH}"
     done <<< "$(bashio::config 'ssh.authorized_keys')"
 fi
+
+# Ensure drop-in config directories exist
+mkdir -p "${SSH_CLIENT_DROPIN_DIR}" "${SSH_HOST_DROPIN_DIR}"
 
 # Port
 sed -i "s/Port\\ .*/Port\\ ${port}/" "${SSH_HOST_CONFIG_PATH}" \

--- a/ssh/rootfs/etc/ssh/ssh_config
+++ b/ssh/rootfs/etc/ssh/ssh_config
@@ -45,6 +45,17 @@
 #   RekeyLimit 1G 1h
 #   UserKnownHostsFile ~/.ssh/known_hosts.d/%k
 
+# User-supplied extras
+# ===================
+# OpenSSH uses unintuitive “first value wins” rules, so any value set in an
+# override file will override the values below only if the Include is *first*.
+#
+# The surrounding directory is created by `/etc/s6-overlay/s6-rc.d/sshd/run`
+# on container startup.
+Include /config/ssh_config.d/*.conf
+
+# Prefer secure ciphers
+# ===================
 HostKeyAlgorithms -ecdsa-sha2-nistp256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521,ecdsa-sha2-nistp521-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256-cert-v01@openssh.com,sk-ecdsa-sha2-nistp256@openssh.com
 KexAlgorithms -diffie-hellman-group14-sha256,ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521
 MACs -hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256,hmac-sha2-512,umac-128@openssh.com,umac-64-etm@openssh.com,umac-64@openssh.com

--- a/ssh/rootfs/etc/ssh/sshd_config
+++ b/ssh/rootfs/etc/ssh/sshd_config
@@ -1,3 +1,12 @@
+# User-supplied extras
+# ===================
+# OpenSSH uses unintuitive “first value wins” rules, so any value set in an
+# override file will override the values below only if the Include is *first*.
+#
+# The surrounding directory is created by `/etc/s6-overlay/s6-rc.d/sshd/run`
+# on container startup.
+Include /config/sshd_config.d/*.conf
+
 # Basics
 # ===================
 Port 22
@@ -7,7 +16,7 @@ ClientAliveInterval 600
 ClientAliveCountMax 3
 UseDNS no
 
-# Loggin
+# Logging
 # ===================
 SyslogFacility AUTH
 LogLevel VERBOSE


### PR DESCRIPTION
# Proposed Changes

Based on Feedback by @frenck on #1057

Configuration are now loaded from /config, the directory is created on startup and the directories in /etc/ssh/* are removed from the image to avoid confusion.

## Related Issues

#1057

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH client and server now support custom configuration drop-in files for extensibility.

* **Bug Fixes**
  * Resolved conflicts between inherited and managed SSH configurations.

* **Documentation**
  * Corrected SSH configuration section header spelling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->